### PR TITLE
github: action for formatting opened PRs

### DIFF
--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -53,6 +53,6 @@ jobs:
             echo "No formatting changes needed"
           else
             git add -A
-            git commit -m "refactor: Apply clang-format to PR files"
+            git commit -m "refactor: Apply clang-format to PR files [skip ci]"
             git push
           fi


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a GitHub Actions workflow that automatically formats C/C++ code in pull requests using clang-format. The workflow triggers on PR events (opened, synchronize, reopened), formats changed files, and commits the changes back with `[skip ci]` to prevent infinite loops.

- Workflow correctly filters only C/C++ file extensions (`.cpp`, `.hpp`, `.h`, `.c`, `.cc`, `.cxx`)
- Uses `--style=file` to respect the existing `.clang-format` configuration in the repository
- Properly configured to push formatting commits with `[skip ci]` marker to prevent recursion
- Only formats files that were actually changed in the PR, minimizing unnecessary formatting churn

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The workflow is well-structured and addresses the infinite loop concern with `[skip ci]`. It follows GitHub Actions best practices and only modifies formatting without changing logic.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/clang-format.yaml | Adds automatic clang-format enforcement on PRs with `[skip ci]` to prevent infinite loops |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->