### PR TITLE
github: add build ci for Windows and Linux

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -1,0 +1,73 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            cc: clang
+            cxx: clang++
+          - os: windows-latest
+            cc: clang
+            cxx: clang++
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Vulkan SDK (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update
+          sudo apt-get install -y vulkan-sdk
+
+      - name: Install Vulkan SDK (Windows)
+        if: runner.os == 'Windows'
+        uses: humbletim/install-vulkan-sdk@v1.1.1
+        with:
+          version: latest
+          cache: true
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build clang libxinerama-dev libxcursor-dev libxi-dev libxrandr-dev libgl1-mesa-dev
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install ninja llvm --yes
+
+      - name: Configure CMake
+        run: |
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_C_COMPILER=${{ matrix.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+
+      - name: Build
+        run: |
+          cmake --build build --config ${{ matrix.build_type }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VulkanW3DViewer-${{ matrix.os }}-${{ matrix.build_type }}
+          path: |
+            build/VulkanW3DViewer*
+            build/shaders/
+          if-no-files-found: warn


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added GitHub Actions workflow to build the VulkanW3DViewer project on Ubuntu and Windows using Clang and Ninja. The workflow installs Vulkan SDK and required dependencies, configures CMake, builds the project in Release mode, and uploads build artifacts including the executable and compiled shaders.

- Configured CI for both Linux (ubuntu-latest) and Windows (windows-latest)
- Clang compiler setup for both platforms
- Vulkan SDK installation via package manager (Linux) and action (Windows)
- Automated artifact upload for executables and shaders
- Security concern: GPG key installation uses pipe to sudo (line 35)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk after addressing the security concern
- The workflow is well-structured and follows GitHub Actions best practices with proper OS-specific conditionals and dependency management. One security issue with piping remote content to sudo should be addressed, but the rest of the implementation is solid
- Pay attention to the GPG key installation step in `.github/workflows/build-os.yml` line 35

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-os.yml | Added CI workflow for building on Ubuntu and Windows with Vulkan SDK and dependencies, minor security concern with key installation |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->