### PR TITLE
github: add build ci for Windows and Linux

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -38,10 +38,15 @@ jobs:
           sudo apt-get install -y vulkan-sdk
       - name: Install Vulkan SDK (Windows)
         if: runner.os == 'Windows'
-        uses: humbletim/install-vulkan-sdk@v1.1.1
-        with:
-          version: latest
-          cache: true
+        shell: pwsh
+        run: |
+          $ver = (Invoke-WebRequest -Uri "https://vulkan.lunarg.com/sdk/latest.json" -UseBasicParsing | ConvertFrom-Json).windows
+          echo "Installing Vulkan SDK version $ver"
+          $installer = "$env:TEMP\VulkanSDK-Installer.exe"
+          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/$ver/windows/VulkanSDK-$ver-Installer.exe" -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -NoNewWindow -Wait
+          echo "VULKAN_SDK=C:\VulkanSDK\$ver" >> $env:GITHUB_ENV
+          echo "C:\VulkanSDK\$ver\Bin" >> $env:GITHUB_PATH
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added GitHub Actions workflow for automated building on Windows and Linux using Clang compiler and Ninja build system.

- Sets up Vulkan SDK installation for both platforms
- Installs platform-specific dependencies (X11 libs for Linux, Chocolatey packages for Windows)
- Configures CMake with Ninja generator and builds in Release mode
- Uploads build artifacts including compiled executable and shaders
- **Issue**: Hardcoded Ubuntu 22.04 (jammy) repository will break when `ubuntu-latest` updates to 24.04+

<h3>Confidence Score: 3/5</h3>


- This PR is safe to merge with moderate risk of future CI breakage
- Score reflects one logical issue (hardcoded Ubuntu version) that will cause CI failures when GitHub updates ubuntu-latest runner, plus minor style issue (missing newline). The workflow structure is sound but needs future-proofing.
- `.github/workflows/build-os.yml` - fix hardcoded Ubuntu version before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-os.yml | Added CI workflow for Windows/Linux builds with Vulkan SDK and dependencies; hardcoded Ubuntu version may break in future |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->