### PR TITLE
ci: run unit tests when PR is openeed to dev

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -20,19 +20,7 @@ jobs:
         sudo apt-get install -y \
           cmake \
           ninja-build \
-          clang \
-          libvulkan-dev \
-          vulkan-validationlayers \
-          spirv-tools \
-          libglfw3-dev \
-          libglm-dev \
-          glslang-tools \
-          libxkbcommon-dev \
-          libwayland-dev \
-          libxrandr-dev \
-          libxinerama-dev \
-          libxcursor-dev \
-          libxi-dev
+          clang
     
     - name: Configure CMake
       run: cmake --preset test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,100 +19,105 @@ if(CMAKE_EXPORT_COMPILE_COMMANDS)
     )
 endif()
 
-# Find Vulkan
-find_package(Vulkan REQUIRED)
-
-# GLFW options - disable unnecessary builds
-set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
-set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-
-# Add GLFW submodule
-add_subdirectory(lib/glfw)
-
-# Add GLM submodule
-add_subdirectory(lib/glm)
-
-# ImGui sources
-set(IMGUI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui)
-set(IMGUI_SOURCES
-    ${IMGUI_DIR}/imgui.cpp
-    ${IMGUI_DIR}/imgui_demo.cpp
-    ${IMGUI_DIR}/imgui_draw.cpp
-    ${IMGUI_DIR}/imgui_tables.cpp
-    ${IMGUI_DIR}/imgui_widgets.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_glfw.cpp
-    ${IMGUI_DIR}/backends/imgui_impl_vulkan.cpp
-)
-
-# Collect source files
-file(GLOB_RECURSE SOURCES "src/*.cpp")
-file(GLOB_RECURSE HEADERS "include/*.hpp" "include/*.h")
-
-# Create executable
-add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES})
-
-# Include directories
-target_include_directories(${PROJECT_NAME} PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/lib/Vulkan-Hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui
-    ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui/backends
-    ${Vulkan_INCLUDE_DIRS}
-)
-
-# Link libraries
-target_link_libraries(${PROJECT_NAME} PRIVATE
-    Vulkan::Vulkan
-    glfw
-    glm::glm
-)
-
-# Compiler-specific flags
-if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
-endif()
-
-# Find glslc shader compiler
-find_program(GLSLC glslc HINTS "$ENV{VULKAN_SDK}/Bin")
-if(NOT GLSLC)
-    message(FATAL_ERROR "glslc not found! Make sure Vulkan SDK is installed.")
-endif()
-
-# Shader compilation function
-function(compile_shaders target)
-    file(GLOB SHADER_SOURCES "${CMAKE_SOURCE_DIR}/shaders/*.vert" "${CMAKE_SOURCE_DIR}/shaders/*.frag")
-    foreach(SHADER ${SHADER_SOURCES})
-        get_filename_component(SHADER_NAME ${SHADER} NAME)
-        set(SPIRV_OUTPUT "${CMAKE_BINARY_DIR}/shaders/${SHADER_NAME}.spv")
-        add_custom_command(
-            OUTPUT ${SPIRV_OUTPUT}
-            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/shaders"
-            COMMAND ${GLSLC} ${SHADER} -o ${SPIRV_OUTPUT}
-            DEPENDS ${SHADER}
-            COMMENT "Compiling ${SHADER_NAME} to SPIR-V"
-        )
-        list(APPEND SPIRV_OUTPUTS ${SPIRV_OUTPUT})
-    endforeach()
-    add_custom_target(${target}_shaders DEPENDS ${SPIRV_OUTPUTS})
-    add_dependencies(${target} ${target}_shaders)
-endfunction()
-
-# Compile shaders
-compile_shaders(${PROJECT_NAME})
-
-# Copy compiled shaders to output directory
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_BINARY_DIR}/shaders
-    $<TARGET_FILE_DIR:${PROJECT_NAME}>/shaders
-)
-
 # Testing with Google Test
 option(BUILD_TESTING "Build tests" OFF)
+
+# Only build main application if not in tests-only mode
+if(NOT BUILD_TESTING)
+    # Find Vulkan
+    find_package(Vulkan REQUIRED)
+
+    # GLFW options - disable unnecessary builds
+    set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+
+    # Add GLFW submodule
+    add_subdirectory(lib/glfw)
+
+    # Add GLM submodule
+    add_subdirectory(lib/glm)
+
+    # ImGui sources
+    set(IMGUI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui)
+    set(IMGUI_SOURCES
+        ${IMGUI_DIR}/imgui.cpp
+        ${IMGUI_DIR}/imgui_demo.cpp
+        ${IMGUI_DIR}/imgui_draw.cpp
+        ${IMGUI_DIR}/imgui_tables.cpp
+        ${IMGUI_DIR}/imgui_widgets.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_glfw.cpp
+        ${IMGUI_DIR}/backends/imgui_impl_vulkan.cpp
+    )
+
+    # Collect source files
+    file(GLOB_RECURSE SOURCES "src/*.cpp")
+    file(GLOB_RECURSE HEADERS "include/*.hpp" "include/*.h")
+
+    # Create executable
+    add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES})
+
+    # Include directories
+    target_include_directories(${PROJECT_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/Vulkan-Hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui/backends
+        ${Vulkan_INCLUDE_DIRS}
+    )
+
+    # Link libraries
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        Vulkan::Vulkan
+        glfw
+        glm::glm
+    )
+
+    # Compiler-specific flags
+    if(MSVC)
+        target_compile_options(${PROJECT_NAME} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    endif()
+
+    # Find glslc shader compiler
+    find_program(GLSLC glslc HINTS "$ENV{VULKAN_SDK}/Bin")
+    if(NOT GLSLC)
+        message(FATAL_ERROR "glslc not found! Make sure Vulkan SDK is installed.")
+    endif()
+
+    # Shader compilation function
+    function(compile_shaders target)
+        file(GLOB SHADER_SOURCES "${CMAKE_SOURCE_DIR}/shaders/*.vert" "${CMAKE_SOURCE_DIR}/shaders/*.frag")
+        foreach(SHADER ${SHADER_SOURCES})
+            get_filename_component(SHADER_NAME ${SHADER} NAME)
+            set(SPIRV_OUTPUT "${CMAKE_BINARY_DIR}/shaders/${SHADER_NAME}.spv")
+            add_custom_command(
+                OUTPUT ${SPIRV_OUTPUT}
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/shaders"
+                COMMAND ${GLSLC} ${SHADER} -o ${SPIRV_OUTPUT}
+                DEPENDS ${SHADER}
+                COMMENT "Compiling ${SHADER_NAME} to SPIR-V"
+            )
+            list(APPEND SPIRV_OUTPUTS ${SPIRV_OUTPUT})
+        endforeach()
+        add_custom_target(${target}_shaders DEPENDS ${SPIRV_OUTPUTS})
+        add_dependencies(${target} ${target}_shaders)
+    endfunction()
+
+    # Compile shaders
+    compile_shaders(${PROJECT_NAME})
+
+    # Copy compiled shaders to output directory
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_BINARY_DIR}/shaders
+        $<TARGET_FILE_DIR:${PROJECT_NAME}>/shaders
+    )
+endif()
+
+# Testing with Google Test
 if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(lib/googletest)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added GitHub Actions workflow to automatically run unit tests when PRs are opened to the dev branch, and refactored `CMakeLists.txt` to conditionally skip Vulkan-dependent builds during testing.

- New workflow (`unit-testing.yml`) runs on Ubuntu, installs minimal dependencies (cmake, ninja, clang), and executes tests using the `test` preset
- `CMakeLists.txt` now wraps main application build in `if(NOT BUILD_TESTING)` guard, allowing test builds to skip Vulkan SDK, GLFW, ImGui, and shader compilation
- Tests can now run in CI without graphics dependencies, improving build times and enabling automated testing on standard CI runners

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-architected and properly separate test builds from application builds. The workflow correctly uses the test preset which sets BUILD_TESTING=ON, and the CMakeLists.txt properly guards Vulkan dependencies. The approach avoids requiring graphics libraries in CI while maintaining the existing build process for development.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/unit-testing.yml | Added CI workflow to run unit tests on PRs to dev branch using cmake test preset |
| CMakeLists.txt | Wrapped main application build in BUILD_TESTING guard to allow tests-only builds without Vulkan |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->