### PR TITLE
build: update include directories to ensure Vulkan header compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,13 +58,14 @@ if(NOT BUILD_TESTING)
     add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${IMGUI_SOURCES})
 
     # Include directories
+    # Use Vulkan headers from Vulkan-Hpp submodule (not system headers) to ensure version compatibility
     target_include_directories(${PROJECT_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/Vulkan-Hpp/Vulkan-Headers/include
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/Vulkan-Hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/imgui/backends
-        ${Vulkan_INCLUDE_DIRS}
     )
 
     # Link libraries


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR updates the CMake build configuration to use Vulkan headers from the `Vulkan-Hpp` submodule instead of system-installed headers. The change adds an explicit include path to `lib/Vulkan-Hpp/Vulkan-Headers/include` and removes `${Vulkan_INCLUDE_DIRS}` to prevent version mismatches between the C++ bindings and C headers. This ensures the project uses compatible versions of Vulkan headers that match the `Vulkan-Hpp` version being used.

- Adds comment explaining the rationale for using submodule headers
- Explicitly includes `Vulkan-Headers` from the `Vulkan-Hpp` submodule
- Removes system Vulkan include directories to avoid conflicts

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward build configuration update that improves header version consistency. It uses vendored headers from submodules instead of system headers, which is a best practice for ensuring reproducible builds. The change is well-commented and aligns with the project's architecture of using git submodules for dependencies.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CMakeLists.txt | Replaced system Vulkan headers with submodule headers to ensure version compatibility between Vulkan-Hpp and Vulkan headers |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->