### PR TITLE
build: create powershell script for fast (re)build / launch

### DIFF
--- a/scripts/rebuild.ps1
+++ b/scripts/rebuild.ps1
@@ -42,7 +42,7 @@ if ($LASTEXITCODE -eq 0) {
     exit 1
 }
 
-if($R) {
+if ($R) {
     Write-Host ""
     Write-Host "Running application for preset: $Preset" -ForegroundColor Yellow
     $exePath = Join-Path $buildDir "VulkanW3DViewer.exe"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added a PowerShell automation script (`rebuild.ps1`) to streamline the CMake build workflow for the three available presets (debug, release, test).

- Validates preset names and provides proper error handling with exit codes
- Supports `-D` flag to delete build directory before rebuild
- Supports `-R` flag to automatically launch the executable after building
- Uses colored console output for better visibility of build status
- Aligns with the build commands documented in `CLAUDE.md`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The script is a straightforward build automation tool that adds developer convenience without modifying any production code. It includes proper validation, error handling, and exit codes. The only issue found is a minor spacing style inconsistency.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/rebuild.ps1 | Added PowerShell automation script for CMake preset rebuilding with optional clean and run flags |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->