### PR TITLE
build: add rebuild script for CMake presets on Linux

### DIFF
--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,11 +1,30 @@
 #!/bin/bash
 # Bash script to rebuild a CMake preset on Linux
-# Usage: ./rebuild-preset.sh debug
+# Usage: ./rebuild-preset.sh [-d] <preset>
 # Available presets: debug, release, test
+# Options:
+#   -d    Delete build directory before rebuilding
+
+DELETE_BUILD=false
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d)
+            DELETE_BUILD=true
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 <preset>"
+    echo "Usage: $0 [-d] <preset>"
     echo "Available presets: debug, release, test"
+    echo "Options:"
+    echo "  -d    Delete build directory before rebuilding"
     exit 1
 fi
 
@@ -24,12 +43,14 @@ esac
 
 BUILD_DIR="build/$PRESET"
 
-echo -e "\033[1;33mDeleting build directory: $BUILD_DIR\033[0m"
-if [ -d "$BUILD_DIR" ]; then
-    rm -rf "$BUILD_DIR"
-    echo -e "\033[1;32mBuild directory deleted.\033[0m"
-else
-    echo -e "\033[1;36mBuild directory does not exist.\033[0m"
+if [ "$DELETE_BUILD" = true ]; then
+    echo -e "\033[1;33mDeleting build directory: $BUILD_DIR\033[0m"
+    if [ -d "$BUILD_DIR" ]; then
+        rm -rf "$BUILD_DIR"
+        echo -e "\033[1;32mBuild directory deleted.\033[0m"
+    else
+        echo -e "\033[1;36mBuild directory does not exist.\033[0m"
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a Linux bash script for rebuilding CMake presets with optional build directory deletion via `-d` flag. The script mirrors the functionality of the existing `rebuild.ps1` PowerShell script, providing cross-platform build tooling.

- Validates preset arguments (debug, release, test)
- Supports optional `-d` flag to delete build directory before rebuilding
- Uses ANSI color codes for colored terminal output
- Properly handles exit codes from CMake commands

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues
- The script is well-structured with proper error handling, argument validation, and exit codes. The `-d` flag implementation makes the behavior consistent with the PowerShell version. The previous review comment about deletion being mandatory has been addressed.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/rebuild.sh | Added Linux build script with optional `-d` flag for deleting build directory before rebuilding |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->