### PR TITLE
fix: initialize bone matrix buffer with rest pose transforms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,6 +255,14 @@ private:
     if (!loadedFile_->hierarchies.empty()) {
       skeletonPose_.computeRestPose(loadedFile_->hierarchies[0]);
       skeletonRenderer_.updateFromPose(context_, skeletonPose_);
+
+      // Initialize bone matrix buffer with rest pose transforms
+      // This ensures models without animations still have correct bone positioning
+      if (skeletonPose_.isValid()) {
+        auto skinningMatrices = skeletonPose_.getSkinningMatrices();
+        boneMatrixBuffer_.update(skinningMatrices);
+      }
+
       console_.info("Loaded skeleton with " + std::to_string(skeletonPose_.boneCount()) + " bones");
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a critical initialization issue where the bone matrix buffer for GPU skinning was not populated for models without animations. The fix ensures models with skeletons but no active animations still render correctly by initializing the buffer with rest pose transforms after skeleton computation.

- Initializes `boneMatrixBuffer_` with rest pose skinning matrices after `skeletonPose_.computeRestPose()`
- Prevents uninitialized bone transforms in GPU skinning for static/non-animated skeletal models
- Matches the existing pattern where bone matrices are updated during animation playback (src/main.cpp:988-991)
- No issues found

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that adds proper initialization for the bone matrix buffer. The implementation correctly mirrors the existing update pattern used during animation playback, uses the same validation checks (`skeletonPose_.isValid()`), and follows the established code style. The fix addresses a real initialization gap where GPU-skinned models without animations would have uninitialized bone matrices.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main.cpp | Added rest pose bone matrix initialization to fix GPU skinning for non-animated models |

</details>



<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=72cb5ca4-667d-4b12-a9f0-b365cec6b2ef))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=c92470f1-c18a-424b-884b-669fcd335279))

<!-- /greptile_comment -->