### PR TITLE
Add GitHub Actions workflow for automated release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
 
           # Generate changelog from commit messages
           # Looking for squashed merge commits which typically have format: "Title (#PR)"
-          CHANGELOG=$(git log $COMMIT_RANGE --oneline --grep="(#[0-9]*)" --pretty=format:"- %s" | head -n 50)
+          CHANGELOG=$(git log $COMMIT_RANGE --oneline --grep='(#[0-9]*)' --pretty=format:"- %s" | head -n 50)
 
           if [ -z "$CHANGELOG" ]; then
             CHANGELOG="- Initial release"


### PR DESCRIPTION
This workflow automatically builds Linux and Windows binaries when PRs from dev are merged into release/* branches.

Features:
- Builds optimized, stripped binaries for Linux (x64) and Windows (x64)
- Uses Clang compiler on both platforms for consistency
- Packages executables with README.md and LICENSE.md
- Generates changelog from merged PR commit messages
- Creates GitHub Release with version tag from branch name
- Supports naming convention: VulkanW3DViewer-{OS}-{arch}-{version}

Workflow jobs:
1. build-linux: Installs Vulkan SDK and dependencies, builds with Clang
2. build-windows: Uses MSYS2/MinGW64 with Clang for Windows builds
3. create-release: Downloads artifacts, generates changelog, creates release

https://claude.ai/code/session_01PXiyM5mdHHWsatAMocWaNB

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a comprehensive GitHub Actions workflow for automated release builds. The workflow triggers on pushes to `release/**` branches and produces optimized, stripped binaries for both Linux (x64) and Windows (x64) platforms using Clang. 

**Key Changes:**
- Automated build pipeline with three jobs: `build-linux`, `build-windows`, and `create-release`
- Version extraction from branch name pattern (`release/VERSION`)
- Vulkan SDK installation on both platforms
- Binary stripping and packaging with README/LICENSE
- Changelog generation from git commit messages with PR references
- Automatic GitHub Release creation with versioned artifacts

**Issues Found:**
- Vulkan SDK installer download lacks checksum verification (security best practice)
- Grep pattern in changelog generation could benefit from explicit quoting for clarity

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor security improvement recommended
- The workflow is well-structured and follows GitHub Actions best practices. Build configurations align with project's CMake presets and CLAUDE.md guidelines (Clang toolchain, release preset). Minor security concern with unverified SDK download and a syntax clarity issue with grep pattern quoting, but neither are critical blockers.
- Review the Vulkan SDK download security (line 113-121) before enabling this workflow in production

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | New GitHub Actions workflow for automated Linux and Windows release builds with changelog generation and artifact packaging |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->