### PR TITLE
build: fix shader compile error on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,14 +111,18 @@ if(NOT BUILD_TESTING)
 
         # Generate embedded shaders header
         set(EMBEDDED_HEADER "${CMAKE_BINARY_DIR}/generated/embedded_shaders.hpp")
+        set(SHADER_LIST_FILE "${CMAKE_BINARY_DIR}/generated/shader_list.txt")
 
-        # Escape semicolons in the list for passing to cmake -P
-        string(REPLACE ";" "\\;" SPIRV_OUTPUTS_ESCAPED "${SPIRV_OUTPUTS}")
+        # Write shader list to a file (more reliable than command-line args)
+        file(WRITE "${SHADER_LIST_FILE}" "")
+        foreach(SHADER_FILE ${SPIRV_OUTPUTS})
+            file(APPEND "${SHADER_LIST_FILE}" "${SHADER_FILE}\n")
+        endforeach()
 
         add_custom_command(
             OUTPUT "${EMBEDDED_HEADER}"
             COMMAND ${CMAKE_COMMAND}
-                "-DSHADER_FILES=${SPIRV_OUTPUTS_ESCAPED}"
+                "-DSHADER_LIST_FILE=${SHADER_LIST_FILE}"
                 "-DOUTPUT_FILE=${EMBEDDED_HEADER}"
                 -P "${CMAKE_SOURCE_DIR}/cmake/EmbedShaders.cmake"
             DEPENDS ${SPIRV_OUTPUTS} "${CMAKE_SOURCE_DIR}/cmake/EmbedShaders.cmake"

--- a/cmake/EmbedShaders.cmake
+++ b/cmake/EmbedShaders.cmake
@@ -1,12 +1,18 @@
 # EmbedShaders.cmake - Generate C++ header with embedded SPIR-V shaders
-# Usage: cmake -DSHADER_FILES="file1;file2;..." -DOUTPUT_FILE="output.hpp" -P EmbedShaders.cmake
+# Usage: cmake -DSHADER_LIST_FILE="list.txt" -DOUTPUT_FILE="output.hpp" -P EmbedShaders.cmake
 
-if(NOT SHADER_FILES)
-  message(FATAL_ERROR "SHADER_FILES not specified")
+if(NOT SHADER_LIST_FILE)
+  message(FATAL_ERROR "SHADER_LIST_FILE not specified")
 endif()
 
 if(NOT OUTPUT_FILE)
   message(FATAL_ERROR "OUTPUT_FILE not specified")
+endif()
+
+# Read shader files from the list file
+file(STRINGS "${SHADER_LIST_FILE}" SHADER_FILES)
+if(NOT SHADER_FILES)
+  message(FATAL_ERROR "No shader files found in ${SHADER_LIST_FILE}")
 endif()
 
 # Ensure output directory exists
@@ -80,7 +86,7 @@ endforeach()
 
 # Create a getter function that returns shader data by name
 file(APPEND "${OUTPUT_FILE}" "// Get shader by name\n")
-file(APPEND "${OUTPUT_FILE}" "inline std::span<const uint8_t> getShader(std::string_view name) {\n")
+file(APPEND "${OUTPUT_FILE}" "inline std::span<const uint8_t> getShader([[maybe_unused]] std::string_view name) {\n")
 
 set(FIRST_SHADER TRUE)
 foreach(SHADER_NAME ${SHADER_NAMES})


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed Windows build failure when embedding shaders by replacing command-line argument passing with a file-based approach.

**Changes:**
- Writes shader file paths to `shader_list.txt` instead of passing as escaped command-line argument
- Updates `EmbedShaders.cmake` to read from file using `file(STRINGS)`
- Adds `[[maybe_unused]]` attribute to `getShader()` parameter to suppress compiler warning when no shaders are present

**Rationale:**
Windows has strict command-line length limits and can mishandle escaped semicolons in long file lists. Writing to an intermediate file is more robust across platforms and scales better with many shader files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a build system improvement
- The changes are straightforward build system fixes that improve cross-platform compatibility. The file-based approach is more reliable than command-line arguments and the `[[maybe_unused]]` attribute is a standard C++ compiler warning suppression
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CMakeLists.txt | Replaced command-line argument passing with file-based approach for shader list to avoid Windows command-line length limits |
| cmake/EmbedShaders.cmake | Updated to read shader list from file instead of command-line argument, added `[[maybe_unused]]` attribute to suppress warning |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->