### PR TITLE
build: add appropriate compile flags based on cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,7 @@ if(NOT BUILD_TESTING)
         target_compile_options(${PROJECT_NAME} PRIVATE
             -Wall -Wextra -Wpedantic -Werror
             $<$<CONFIG:Debug>:-O0 -g>
-            $<$<CONFIG:Release>:-O3 -flto>
-        )
-        target_link_options(${PROJECT_NAME} PRIVATE
-            $<$<CONFIG:Release>:-flto>
+            $<$<CONFIG:Release>:-O3>
         )
     endif()
 


### PR DESCRIPTION
- Closes #34

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removes LTO (Link-Time Optimization) flags from non-MSVC compiler builds while keeping appropriate optimization and debug flags for each configuration.

- For Debug builds: `-O0` (no optimization) and `-g` (debug symbols)
- For Release builds: `-O3` (aggressive optimization) without LTO
- Removed both `-flto` compile and link options that were added in the previous commit

<h3>Confidence Score: 5/5</h3>

- Safe to merge - removes LTO flags that may have been causing build issues
- Changes are straightforward build configuration adjustments that remove LTO optimization flags while preserving essential Debug/Release optimization levels. No functional code changes or risks introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CMakeLists.txt | Removed LTO flags from non-MSVC builds, keeping appropriate optimization flags for Debug/Release configs |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->