### PR TITLE
docs: add AGENTS.md with development environment tips

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -4,7 +4,7 @@ The project is an updated implementation of viewing the WestWood W3D format for 
 The project aims to update the old codebase to newer supported frameworks.
 
 - If the legacy code is in the codebase, it will be located under `PROJECT_ROOT/legacy/`.
-- Use `cmake --preset $preset` to configur.
+- Use `cmake --preset $preset` to configure.
 - Use `cmake --build --preset $preset` to build.
 - Use `build/$preset/VulkanW3DViewer(.exe) $modelPath` to load a model on application startup.
 - Use `build/$preset/VulkanW3DViewer(.exe) -d` for debug.
@@ -23,11 +23,11 @@ Unintuitive behaviors in the W3D format that require special handling:
 
 ## Testing instructions
 - Where it make sense create unit tests for new code or updated existing code.
-- Attempt to keep test c    overage high, while not adding graphic dependencies.
+- Attempt to keep test coverage high, while not adding graphic dependencies.
 - To compile test run the `test` preset.
 - Use `ctest --preset test` to run the tests.
 
 ## PR instructions
 Uses the conventional commit format with the default types.
 - Title format: `<type>: <description>`
-- Run Clang-format and run the application before commiting. 
+- Run Clang-format and run the application before committing. 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `.github/AGENTS.md` to provide development environment guidance for AI agents and developers working on the Vulkan W3D viewer project.

- Documented build and run commands with preset variables
- Listed W3D format quirks and special handling requirements
- Added testing instructions with `ctest` commands
- Specified PR requirements for conventional commit format
- Three spelling errors need correction: "configur" → "configure", "c    overage" → "coverage", "commiting" → "committing"

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing spelling errors
- Documentation-only change with helpful content but contains three spelling errors that should be corrected
- `.github/AGENTS.md` needs spelling corrections before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/AGENTS.md | Added development environment documentation with minor spelling errors (configur, c overage, commiting) |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->