### PR TITLE
chore: remove unessesary debug code from main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,6 @@
 #include <iostream>
 
 #include "core/application.hpp"
-
-#include "core/application.hpp"
 #include "w3d/loader.hpp"
 
 void printUsage(const char *programName) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `--list-textures` (`-l`) command-line flag and its implementation, which was a debug utility for analyzing texture references in W3D files.

**Changes:**
- Removed unused includes: `<algorithm>`, `<filesystem>`, `<set>`, `<stdexchept>`
- Removed `--list-textures` flag from help text and argument parser
- Removed ~76 lines of texture analysis code that listed textures and checked path resolution

**Issue found:**
- Duplicate `#include "core/application.hpp"` on lines 4 and 6

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the duplicate include
- The PR successfully removes debug code as intended, but contains a duplicate include that should be fixed before merging
- src/main.cpp needs the duplicate include removed

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/main.cpp | removed unused `--list-textures` debug flag and related code; contains duplicate include statement |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->