### PR TITLE
Implement release-branch flow with automated tagging and syncing

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,46 @@
+name: Auto-tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version and create tag
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "Tagging as: $VERSION"
+
+          # Validate version format (vX.Y.Z with optional pre-release suffix)
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "ERROR: Version '$VERSION' does not match expected format vX.Y.Z[-suffix]"
+            exit 1
+          fi
+
+          # Validate against CMakeLists.txt (warning only)
+          CMAKE_VERSION=$(grep -oP 'project\(.*VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt || echo "")
+          TAG_VERSION="${VERSION#v}"
+          TAG_BASE="${TAG_VERSION%%-*}"
+          if [ -n "$CMAKE_VERSION" ] && [ "$CMAKE_VERSION" != "$TAG_BASE" ]; then
+            echo "WARNING: CMakeLists.txt version ($CMAKE_VERSION) differs from tag version ($TAG_BASE)"
+            echo "Please ensure these are aligned."
+          fi
+
+          # Create and push the tag
+          git tag "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
       - 'release/**'
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release Build
 
 on:
   push:
-    branches:
-      - 'release/**'
+    tags:
+      - 'v*'
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
@@ -20,10 +20,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Extract version from branch name
+      - name: Extract version from tag
         id: extract-version
         run: |
-          VERSION=${GITHUB_REF#refs/heads/release/}
+          VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
@@ -84,10 +84,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Extract version from branch name
+      - name: Extract version from tag
         id: extract-version
         run: |
-          VERSION=${GITHUB_REF#refs/heads/release/}
+          VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
@@ -155,6 +155,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Download Linux artifact
         uses: actions/download-artifact@v4
@@ -172,8 +173,8 @@ jobs:
           VERSION=${{ needs.build-linux.outputs.version }}
           echo "Generating changelog for $VERSION"
 
-          # Get the last release tag
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Get the previous release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 --exclude="$VERSION" 2>/dev/null || echo "")
 
           if [ -z "$LAST_TAG" ]; then
             echo "No previous release found, generating full history"
@@ -212,15 +213,13 @@ jobs:
           cat changelog.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.build-linux.outputs.version }}
-          name: Release ${{ needs.build-linux.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body_path: changelog.md
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
           files: |
             VulkanW3DViewer-linux-x64-${{ needs.build-linux.outputs.version }}.tar.gz
             VulkanW3DViewer-windows-x64-${{ needs.build-linux.outputs.version }}.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,52 @@
+name: Sync dev with main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into dev
+        id: merge
+        run: |
+          git fetch origin dev || { echo "dev branch does not exist yet, skipping sync"; echo "skip=true" >> $GITHUB_OUTPUT; exit 0; }
+          git checkout dev
+
+          if git merge origin/main --no-edit -m "chore: Merge main into dev [skip ci]"; then
+            git push origin dev
+            echo "conflict=false" >> $GITHUB_OUTPUT
+          else
+            git merge --abort
+            SYNC_BRANCH="sync/main-to-dev-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b "$SYNC_BRANCH" origin/main
+            git push origin "$SYNC_BRANCH"
+            echo "conflict=true" >> $GITHUB_OUTPUT
+            echo "sync_branch=$SYNC_BRANCH" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR if conflict
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "sync: Merge main into dev (resolve conflicts)" \
+            --body "Automated sync from main to dev after release. Manual conflict resolution required." \
+            --base dev \
+            --head "${{ steps.merge.outputs.sync_branch }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(VulkanW3DViewer VERSION 1.0.0 LANGUAGES CXX)
+project(VulkanW3DViewer VERSION 0.2.0 LANGUAGES CXX)
 
 # C++26 standard
 set(CMAKE_CXX_STANDARD 20)

--- a/docs/development/branching-strategy.md
+++ b/docs/development/branching-strategy.md
@@ -1,0 +1,106 @@
+# Branching Strategy
+
+This project uses a **release-branch flow** designed to keep `main` always reflecting the latest release while allowing continuous development on `dev`.
+
+## Branch Roles
+
+| Branch | Purpose | Merges from | Merges to |
+|--------|---------|-------------|-----------|
+| `main` | Latest release only | `release/*` via PR | Synced back to `dev` |
+| `dev` | Next release accumulator | `feature/*`, `fix/*` via PR | Cut `release/*` branches |
+| `feature/*`, `fix/*` | Individual work items | Branched from `dev` | PR to `dev` |
+| `release/vX.Y.Z` | Release stabilization | Cut from `dev` | PR to `main` |
+
+## Flow Diagram
+
+```mermaid
+gitGraph
+    commit id: "v0.2.0"
+    branch dev
+    commit id: "feat: A"
+    commit id: "feat: B"
+    commit id: "fix: C"
+    branch release/v0.3.0
+    commit id: "chore: bump version"
+    checkout main
+    merge release/v0.3.0 id: "Release v0.3.0"
+    checkout dev
+    merge main id: "sync"
+    commit id: "feat: D"
+```
+
+## Rules
+
+1. **Never push directly to `main` or `dev`** -- all changes arrive via pull requests.
+2. **Flow is one-directional:** `feature` -> `dev` -> `release` -> `main` -> (sync back to `dev`).
+3. **After every release merge**, `main` is automatically synced back to `dev` via the `sync-dev.yml` workflow. This prevents merge conflicts.
+4. **Release branches are short-lived** -- days, not weeks. Cut them when `dev` is ready, stabilize quickly, merge to `main`.
+
+## Development Workflow
+
+### Working on a Feature or Fix
+
+```bash
+# Start from dev
+git checkout dev
+git pull origin dev
+
+# Create your branch
+git checkout -b feature/add-texture-filtering
+
+# ... develop, commit ...
+
+# Push and open a PR targeting dev
+git push -u origin feature/add-texture-filtering
+```
+
+Open a PR from `feature/add-texture-filtering` to `dev`. The PR test matrix and clang-format will run automatically.
+
+### Cutting a Release
+
+When `dev` has accumulated enough changes for a release:
+
+```bash
+# Start from dev
+git checkout dev
+git pull origin dev
+
+# Create the release branch (must follow vX.Y.Z naming)
+git checkout -b release/v0.3.0
+```
+
+On the release branch:
+
+1. **Bump the version** in `CMakeLists.txt` (the `project(... VERSION X.Y.Z ...)` line).
+2. Apply only bugfixes if issues are found during testing.
+3. Push and open a PR targeting `main`.
+
+```bash
+git push -u origin release/v0.3.0
+```
+
+### What Happens on Merge
+
+When the release PR is merged to `main`, three things happen automatically:
+
+1. **`auto-tag.yml`** creates a git tag `vX.Y.Z` from the release branch name.
+2. **`release.yml`** triggers on the new tag, builds Linux and Windows binaries, and creates a GitHub Release with artifacts and changelog.
+3. **`sync-dev.yml`** merges `main` back into `dev` to keep them aligned. If there are conflicts (rare), it creates a PR for manual resolution instead.
+
+## Version Naming
+
+- Tags follow the format `vX.Y.Z` (e.g., `v0.3.0`)
+- Pre-release suffixes are supported: `v0.3.0-alpha`, `v0.3.0-beta`
+- Tags containing `alpha` or `beta` are automatically marked as pre-releases on GitHub
+- The version in `CMakeLists.txt` should match the base version (without the `v` prefix or pre-release suffix)
+
+## CI/CD Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `pr-test.yml` | PRs to `dev`, `main`, `release/**` | Multi-platform test matrix (Linux GCC/Clang, Windows MSVC/Clang) |
+| `clang-format.yaml` | All PRs | Auto-format C/C++ files |
+| `auto-tag.yml` | Release PR merged to `main` | Creates git tag from release branch name |
+| `release.yml` | Tag push (`v*`) | Builds artifacts and creates GitHub Release |
+| `sync-dev.yml` | Push to `main` | Merges `main` back into `dev` |
+| `docs.yml` | Push to `main` (docs paths) | Deploys documentation site |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
     - HLod: w3d-format/hlod.md
   - Development:
     - development/index.md
+    - Branching Strategy: development/branching-strategy.md
     - Code Style: development/code-style.md
     - Testing: development/testing.md
     - Contributing: development/contributing.md


### PR DESCRIPTION
## Summary

This PR establishes a formal branching strategy and CI/CD workflow for the project, transitioning from direct release branch builds to a tag-based release process with automated synchronization between `main` and `dev` branches.

## Key Changes

- **Branching Strategy Documentation** (`docs/development/branching-strategy.md`)
  - Defined release-branch flow: `feature/*` → `dev` → `release/*` → `main` → sync back to `dev`
  - Documented all branch roles, development workflow, and version naming conventions
  - Added CI/CD workflow reference table

- **Automated Release Tagging** (`.github/workflows/auto-tag.yml`)
  - New workflow that automatically creates git tags when release PRs merge to `main`
  - Extracts version from `release/vX.Y.Z` branch name and validates format
  - Warns if CMakeLists.txt version doesn't match tag version

- **Automated Dev Sync** (`.github/workflows/sync-dev.yml`)
  - New workflow that merges `main` back into `dev` after every release
  - Handles merge conflicts gracefully by creating a PR for manual resolution
  - Prevents divergence between branches and reduces future merge conflicts

- **Release Workflow Updates** (`.github/workflows/release.yml`)
  - Changed trigger from `release/**` branches to `v*` tags
  - Updated version extraction to use git tags instead of branch names
  - Improved changelog generation to exclude current tag when finding previous release
  - Added pre-release detection: tags with `alpha` or `beta` automatically marked as pre-releases
  - Updated to `softprops/action-gh-release@v2`

- **PR Test Coverage** (`.github/workflows/pr-test.yml`)
  - Extended test matrix to run on PRs targeting `main` branch (in addition to `dev` and `release/**`)

- **Version Bump** (`CMakeLists.txt`)
  - Updated project version from `1.0.0` to `0.2.0` to align with release strategy

- **Documentation Navigation** (`mkdocs.yml`)
  - Added branching strategy guide to development section

## Implementation Details

The workflow now follows this sequence:
1. Features merge to `dev` via PR
2. When ready for release, cut `release/vX.Y.Z` branch from `dev`
3. Merge release PR to `main` → triggers `auto-tag.yml`
4. Tag creation → triggers `release.yml` to build and publish artifacts
5. Push to `main` → triggers `sync-dev.yml` to keep branches aligned

This ensures `main` always reflects the latest release while `dev` accumulates changes for the next release, with all synchronization automated to prevent manual errors.

https://claude.ai/code/session_01HtRSAEVeRDQM2uusdxy3bq