### PR TITLE
ci: update pr-test workflow to only run with changes to C++ files

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       cpp: ${{ steps.filter.outputs.cpp }}
       workflow: ${{ steps.filter.outputs.workflow }}
@@ -22,12 +24,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Detect changed files
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            cpp: 'src/**|tests/**|CMakeLists.txt|cmake/**'
-            workflow: '.github/workflows/pr-test.yml'
+            cpp:
+              - 'src/**'
+              - 'tests/**'
+              - 'CMakeLists.txt'
+              - 'cmake/**'
+              - 'shaders/**'
+            workflow:
+              - '.github/workflows/pr-test.yml'
 
   test:
     needs: changes

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,7 +11,27 @@ env:
   BUILD_TYPE: test
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      cpp: ${{ steps.filter.outputs.cpp }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect changed files
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            cpp: 'src/**|tests/**|CMakeLists.txt|cmake/**'
+            workflow: '.github/workflows/pr-test.yml'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description
PR-test now only run on PRs which changes C++ files or build system files. 

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] Formatting
- [ ] Refactoring
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Tests
- [ ] Other
