### PR TITLE
chore: update bigx library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(NOT BUILD_TESTING)
         Vulkan::Vulkan
         glfw
         glm::glm
-        big::big
+        bigx::bigx
     )
 
     # Compiler-specific flags

--- a/src/lib/formats/big/asset_registry.cpp
+++ b/src/lib/formats/big/asset_registry.cpp
@@ -150,7 +150,7 @@ bool AssetRegistry::scanArchives(const std::filesystem::path &gameDirectory,
 bool AssetRegistry::scanArchive(const std::filesystem::path &archivePath,
                                 const std::string &archiveName, std::string *outError) {
   std::string error;
-  auto archive = ::big::Archive::open(archivePath, &error);
+  auto archive = ::bigx::Archive::open(archivePath, &error);
 
   if (!archive) {
     if (outError) {

--- a/src/lib/formats/big/big_archive_manager.cpp
+++ b/src/lib/formats/big/big_archive_manager.cpp
@@ -55,7 +55,7 @@ bool BigArchiveManager::loadArchives(std::string *outError) {
     std::filesystem::path archivePath = gameDirectory_ / archiveName;
 
     std::string error;
-    auto archive = ::big::Archive::open(archivePath, &error);
+    auto archive = ::bigx::Archive::open(archivePath, &error);
 
     if (archive) {
       archives_[archiveName] = std::move(*archive);
@@ -95,7 +95,7 @@ bool BigArchiveManager::loadArchives(std::string *outError) {
         }
 
         std::string error;
-        auto archive = ::big::Archive::open(path, &error);
+        auto archive = ::bigx::Archive::open(path, &error);
 
         if (archive) {
           archives_[key] = std::move(*archive);
@@ -149,7 +149,7 @@ bool BigArchiveManager::initialize(const std::filesystem::path &gameDirectory,
   return true;
 }
 
-const ::big::FileEntry *BigArchiveManager::findAsset(const std::string &archivePath) const {
+const ::bigx::FileEntry *BigArchiveManager::findAsset(const std::string &archivePath) const {
   // Search in all loaded archives
   for (const auto &pair : archives_) {
     const auto *entry = pair.second.findFile(archivePath);

--- a/src/lib/formats/big/big_archive_manager.hpp
+++ b/src/lib/formats/big/big_archive_manager.hpp
@@ -72,12 +72,12 @@ private:
   bool initialized_ = false;
   std::filesystem::path gameDirectory_;
   std::filesystem::path cacheDirectory_;
-  std::unordered_map<std::string, ::big::Archive> archives_;
+  std::unordered_map<std::string, ::bigx::Archive> archives_;
 
   /// Find asset in all loaded archives
   /// @param archivePath Path to search for
   /// @return File entry if found, nullptr otherwise
-  const ::big::FileEntry *findAsset(const std::string &archivePath) const;
+  const ::bigx::FileEntry *findAsset(const std::string &archivePath) const;
 
   /// Get cache file path for an archive path
   /// @param archivePath Path within the archive

--- a/src/lib/formats/big/ini_extractor.cpp
+++ b/src/lib/formats/big/ini_extractor.cpp
@@ -38,7 +38,7 @@ std::vector<std::string> IniExtractor::listIniFiles(const std::filesystem::path 
     std::filesystem::path archivePath = gameDirectory / archiveName;
 
     std::string error;
-    auto archive = ::big::Archive::open(archivePath, &error);
+    auto archive = ::bigx::Archive::open(archivePath, &error);
 
     if (!archive) {
       continue; // Skip archives that don't exist
@@ -80,7 +80,7 @@ size_t IniExtractor::extractAllIni(const std::filesystem::path &gameDirectory,
     std::filesystem::path archivePath = gameDirectory / archiveName;
 
     std::string error;
-    auto archive = ::big::Archive::open(archivePath, &error);
+    auto archive = ::bigx::Archive::open(archivePath, &error);
 
     if (!archive) {
       continue; // Skip archives that don't exist


### PR DESCRIPTION
# Description
Update BigXtractor to the new version - which has a new cmake variable for the test suite more specific to the bigx library and updated namespace to not conflict with other filetypes. `big` -> `bigx`

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] Formatting
- [ ] Refactoring
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Tests
- [x] Other