### PR TITLE
ci: make tests run after the clang-formatter

### DIFF
--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -53,6 +53,6 @@ jobs:
             echo "No formatting changes needed"
           else
             git add -A
-            git commit -m "refactor: Apply clang-format to PR files [skip ci]"
+            git commit -m "refactor: Apply clang-format to PR files"
             git push
           fi

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,7 +1,10 @@
 name: PR Test
 
 on:
-  pull_request:
+  workflow_run:
+    workflows: ['clang-format']
+    types:
+      - completed
     branches:
       - dev
       - main


### PR DESCRIPTION
# Description
Adds a requirement to the pr-test workflow to only start after the clang-format workflow has completed. This ensures that tests are run on the most up to date version of the change

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Formatting
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Tests
- [ ] Other