### PR TITLE
feat: add scene graph with spatial indexing and object placement

### DIFF
--- a/src/lib/formats/map/types.hpp
+++ b/src/lib/formats/map/types.hpp
@@ -129,7 +129,9 @@ struct MapObject {
 
   bool isBridgePoint() const { return (flags & (FLAG_BRIDGE_POINT1 | FLAG_BRIDGE_POINT2)) != 0; }
 
-  bool shouldRender() const { return (flags & FLAG_DONT_RENDER) == 0; }
+  bool shouldRender() const {
+    return (flags & FLAG_DONT_RENDER) == 0 && !isRoadPoint() && !isBridgePoint();
+  }
 };
 
 struct PolygonTrigger {

--- a/src/lib/scene/quadtree.cpp
+++ b/src/lib/scene/quadtree.cpp
@@ -67,10 +67,10 @@ void Quadtree::subdivide(int nodeIndex) {
   float midZ = (nodes_[nodeIndex].bounds.minZ + nodes_[nodeIndex].bounds.maxZ) * 0.5f;
 
   Rect quads[4] = {
-      {nodes_[nodeIndex].bounds.minX, nodes_[nodeIndex].bounds.minZ, midX, midZ},
-      {midX, nodes_[nodeIndex].bounds.minZ, nodes_[nodeIndex].bounds.maxX, midZ},
-      {nodes_[nodeIndex].bounds.minX, midZ, midX, nodes_[nodeIndex].bounds.maxZ},
-      {midX, midZ, nodes_[nodeIndex].bounds.maxX, nodes_[nodeIndex].bounds.maxZ},
+      {nodes_[nodeIndex].bounds.minX, nodes_[nodeIndex].bounds.minZ, midX,                          midZ                         },
+      {midX,                          nodes_[nodeIndex].bounds.minZ, nodes_[nodeIndex].bounds.maxX, midZ                         },
+      {nodes_[nodeIndex].bounds.minX, midZ,                          midX,                          nodes_[nodeIndex].bounds.maxZ},
+      {midX,                          midZ,                          nodes_[nodeIndex].bounds.maxX, nodes_[nodeIndex].bounds.maxZ},
   };
 
   int baseIndex = static_cast<int>(nodes_.size());

--- a/src/lib/scene/quadtree.cpp
+++ b/src/lib/scene/quadtree.cpp
@@ -1,0 +1,171 @@
+#include "quadtree.hpp"
+
+#include <algorithm>
+
+namespace w3d::scene {
+
+Quadtree::Quadtree(float minX, float minZ, float maxX, float maxZ, int maxDepth, int maxPerNode)
+    : maxDepth_(maxDepth), maxPerNode_(maxPerNode) {
+  Node root;
+  root.bounds = {minX, minZ, maxX, maxZ};
+  nodes_.push_back(root);
+}
+
+Quadtree::Rect Quadtree::nodeWorldRect(const SceneNode *node) const {
+  gfx::BoundingBox wb = node->worldBounds();
+  if (wb.valid()) {
+    return {wb.min.x, wb.min.z, wb.max.x, wb.max.z};
+  }
+  const glm::vec3 &pos = node->position();
+  constexpr float kFallbackHalf = 1.0f;
+  return {pos.x - kFallbackHalf, pos.z - kFallbackHalf, pos.x + kFallbackHalf,
+          pos.z + kFallbackHalf};
+}
+
+void Quadtree::insert(SceneNode *node) {
+  Entry entry;
+  entry.node = node;
+  entry.bounds = nodeWorldRect(node);
+  insertInto(0, entry, 0);
+}
+
+void Quadtree::insertInto(int nodeIndex, const Entry &entry, int depth) {
+  Node &n = nodes_[nodeIndex];
+
+  if (n.isLeaf) {
+    n.entries.push_back(entry);
+    if (static_cast<int>(n.entries.size()) > maxPerNode_ && depth < maxDepth_) {
+      subdivide(nodeIndex);
+    }
+    return;
+  }
+
+  float cx = (entry.bounds.minX + entry.bounds.maxX) * 0.5f;
+  float cz = (entry.bounds.minZ + entry.bounds.maxZ) * 0.5f;
+
+  for (int ci : n.children) {
+    if (ci < 0)
+      continue;
+    if (nodes_[ci].bounds.contains(cx, cz)) {
+      insertInto(ci, entry, depth + 1);
+      return;
+    }
+  }
+
+  for (int ci : n.children) {
+    if (ci < 0)
+      continue;
+    if (nodes_[ci].bounds.intersects(entry.bounds)) {
+      insertInto(ci, entry, depth + 1);
+      return;
+    }
+  }
+}
+
+void Quadtree::subdivide(int nodeIndex) {
+  float midX = (nodes_[nodeIndex].bounds.minX + nodes_[nodeIndex].bounds.maxX) * 0.5f;
+  float midZ = (nodes_[nodeIndex].bounds.minZ + nodes_[nodeIndex].bounds.maxZ) * 0.5f;
+
+  Rect quads[4] = {
+      {nodes_[nodeIndex].bounds.minX, nodes_[nodeIndex].bounds.minZ, midX, midZ},
+      {midX, nodes_[nodeIndex].bounds.minZ, nodes_[nodeIndex].bounds.maxX, midZ},
+      {nodes_[nodeIndex].bounds.minX, midZ, midX, nodes_[nodeIndex].bounds.maxZ},
+      {midX, midZ, nodes_[nodeIndex].bounds.maxX, nodes_[nodeIndex].bounds.maxZ},
+  };
+
+  int baseIndex = static_cast<int>(nodes_.size());
+  nodes_[nodeIndex].children[0] = baseIndex;
+  nodes_[nodeIndex].children[1] = baseIndex + 1;
+  nodes_[nodeIndex].children[2] = baseIndex + 2;
+  nodes_[nodeIndex].children[3] = baseIndex + 3;
+  nodes_[nodeIndex].isLeaf = false;
+
+  nodes_.reserve(nodes_.size() + 4);
+  for (int i = 0; i < 4; ++i) {
+    Node child;
+    child.bounds = quads[i];
+    nodes_.push_back(child);
+  }
+
+  std::vector<Entry> entries = std::move(nodes_[nodeIndex].entries);
+  nodes_[nodeIndex].entries.clear();
+
+  for (const auto &entry : entries) {
+    insertInto(nodeIndex, entry, 1);
+  }
+}
+
+void Quadtree::clear() {
+  float minX = nodes_[0].bounds.minX;
+  float minZ = nodes_[0].bounds.minZ;
+  float maxX = nodes_[0].bounds.maxX;
+  float maxZ = nodes_[0].bounds.maxZ;
+  nodes_.clear();
+  Node root;
+  root.bounds = {minX, minZ, maxX, maxZ};
+  nodes_.push_back(root);
+}
+
+void Quadtree::query(const Rect &rect, std::vector<SceneNode *> &result) const {
+  queryNode(0, rect, result);
+}
+
+void Quadtree::query(const gfx::Frustum &frustum, std::vector<SceneNode *> &result) const {
+  queryNodeFrustum(0, frustum, result);
+}
+
+void Quadtree::queryNode(int nodeIndex, const Rect &rect, std::vector<SceneNode *> &result) const {
+  const Node &n = nodes_[nodeIndex];
+
+  if (!n.bounds.intersects(rect))
+    return;
+
+  for (const auto &entry : n.entries) {
+    if (entry.bounds.intersects(rect)) {
+      result.push_back(entry.node);
+    }
+  }
+
+  if (!n.isLeaf) {
+    for (int ci : n.children) {
+      if (ci >= 0) {
+        queryNode(ci, rect, result);
+      }
+    }
+  }
+}
+
+bool Quadtree::rectIntersectsFrustum(const Rect &rect, const gfx::Frustum &frustum) {
+  gfx::BoundingBox box;
+  box.expand(glm::vec3(rect.minX, -1e6f, rect.minZ));
+  box.expand(glm::vec3(rect.maxX, 1e6f, rect.maxZ));
+  return frustum.isBoxVisible(box);
+}
+
+void Quadtree::queryNodeFrustum(int nodeIndex, const gfx::Frustum &frustum,
+                                std::vector<SceneNode *> &result) const {
+  const Node &n = nodes_[nodeIndex];
+
+  if (!rectIntersectsFrustum(n.bounds, frustum))
+    return;
+
+  for (const auto &entry : n.entries) {
+    gfx::BoundingBox entryBox;
+    entryBox.expand(glm::vec3(entry.bounds.minX, -1e6f, entry.bounds.minZ));
+    entryBox.expand(glm::vec3(entry.bounds.maxX, 1e6f, entry.bounds.maxZ));
+    if (frustum.isBoxVisible(entry.node->worldBounds().valid() ? entry.node->worldBounds()
+                                                               : entryBox)) {
+      result.push_back(entry.node);
+    }
+  }
+
+  if (!n.isLeaf) {
+    for (int ci : n.children) {
+      if (ci >= 0) {
+        queryNodeFrustum(ci, frustum, result);
+      }
+    }
+  }
+}
+
+} // namespace w3d::scene

--- a/src/lib/scene/quadtree.cpp
+++ b/src/lib/scene/quadtree.cpp
@@ -35,7 +35,7 @@ void Quadtree::insertInto(int nodeIndex, const Entry &entry, int depth) {
   if (n.isLeaf) {
     n.entries.push_back(entry);
     if (static_cast<int>(n.entries.size()) > maxPerNode_ && depth < maxDepth_) {
-      subdivide(nodeIndex);
+      subdivide(nodeIndex, depth);
     }
     return;
   }
@@ -62,7 +62,7 @@ void Quadtree::insertInto(int nodeIndex, const Entry &entry, int depth) {
   }
 }
 
-void Quadtree::subdivide(int nodeIndex) {
+void Quadtree::subdivide(int nodeIndex, int depth) {
   float midX = (nodes_[nodeIndex].bounds.minX + nodes_[nodeIndex].bounds.maxX) * 0.5f;
   float midZ = (nodes_[nodeIndex].bounds.minZ + nodes_[nodeIndex].bounds.maxZ) * 0.5f;
 
@@ -91,7 +91,7 @@ void Quadtree::subdivide(int nodeIndex) {
   nodes_[nodeIndex].entries.clear();
 
   for (const auto &entry : entries) {
-    insertInto(nodeIndex, entry, 1);
+    insertInto(nodeIndex, entry, depth);
   }
 }
 

--- a/src/lib/scene/quadtree.hpp
+++ b/src/lib/scene/quadtree.hpp
@@ -48,7 +48,7 @@ private:
 
   [[nodiscard]] Rect nodeWorldRect(const SceneNode *node) const;
   void insertInto(int nodeIndex, const Entry &entry, int depth);
-  void subdivide(int nodeIndex);
+  void subdivide(int nodeIndex, int depth);
   void queryNode(int nodeIndex, const Rect &rect, std::vector<SceneNode *> &result) const;
   void queryNodeFrustum(int nodeIndex, const gfx::Frustum &frustum,
                         std::vector<SceneNode *> &result) const;

--- a/src/lib/scene/quadtree.hpp
+++ b/src/lib/scene/quadtree.hpp
@@ -25,8 +25,7 @@ public:
     }
   };
 
-  Quadtree(float minX, float minZ, float maxX, float maxZ, int maxDepth = 6,
-           int maxPerNode = 8);
+  Quadtree(float minX, float minZ, float maxX, float maxZ, int maxDepth = 6, int maxPerNode = 8);
 
   void insert(SceneNode *node);
   void clear();
@@ -53,8 +52,7 @@ private:
   void queryNode(int nodeIndex, const Rect &rect, std::vector<SceneNode *> &result) const;
   void queryNodeFrustum(int nodeIndex, const gfx::Frustum &frustum,
                         std::vector<SceneNode *> &result) const;
-  [[nodiscard]] static bool rectIntersectsFrustum(const Rect &rect,
-                                                  const gfx::Frustum &frustum);
+  [[nodiscard]] static bool rectIntersectsFrustum(const Rect &rect, const gfx::Frustum &frustum);
 
   std::vector<Node> nodes_;
   int maxDepth_;

--- a/src/lib/scene/quadtree.hpp
+++ b/src/lib/scene/quadtree.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <vector>
+
+#include "lib/gfx/bounding_box.hpp"
+#include "lib/gfx/frustum.hpp"
+#include "lib/scene/scene_node.hpp"
+
+namespace w3d::scene {
+
+class Quadtree {
+public:
+  struct Rect {
+    float minX = 0.0f;
+    float minZ = 0.0f;
+    float maxX = 0.0f;
+    float maxZ = 0.0f;
+
+    [[nodiscard]] bool intersects(const Rect &other) const {
+      return minX <= other.maxX && maxX >= other.minX && minZ <= other.maxZ && maxZ >= other.minZ;
+    }
+
+    [[nodiscard]] bool contains(float x, float z) const {
+      return x >= minX && x <= maxX && z >= minZ && z <= maxZ;
+    }
+  };
+
+  Quadtree(float minX, float minZ, float maxX, float maxZ, int maxDepth = 6,
+           int maxPerNode = 8);
+
+  void insert(SceneNode *node);
+  void clear();
+
+  void query(const Rect &rect, std::vector<SceneNode *> &result) const;
+  void query(const gfx::Frustum &frustum, std::vector<SceneNode *> &result) const;
+
+private:
+  struct Entry {
+    SceneNode *node = nullptr;
+    Rect bounds;
+  };
+
+  struct Node {
+    Rect bounds;
+    std::vector<Entry> entries;
+    int children[4] = {-1, -1, -1, -1};
+    bool isLeaf = true;
+  };
+
+  [[nodiscard]] Rect nodeWorldRect(const SceneNode *node) const;
+  void insertInto(int nodeIndex, const Entry &entry, int depth);
+  void subdivide(int nodeIndex);
+  void queryNode(int nodeIndex, const Rect &rect, std::vector<SceneNode *> &result) const;
+  void queryNodeFrustum(int nodeIndex, const gfx::Frustum &frustum,
+                        std::vector<SceneNode *> &result) const;
+  [[nodiscard]] static bool rectIntersectsFrustum(const Rect &rect,
+                                                  const gfx::Frustum &frustum);
+
+  std::vector<Node> nodes_;
+  int maxDepth_;
+  int maxPerNode_;
+};
+
+} // namespace w3d::scene

--- a/src/lib/scene/scene_graph.cpp
+++ b/src/lib/scene/scene_graph.cpp
@@ -1,0 +1,38 @@
+#include "scene_graph.hpp"
+
+namespace w3d::scene {
+
+SceneGraph::SceneGraph(float worldMinX, float worldMinZ, float worldMaxX, float worldMaxZ)
+    : quadtree_(worldMinX, worldMinZ, worldMaxX, worldMaxZ) {}
+
+SceneNode *SceneGraph::addNode(std::unique_ptr<SceneNode> node) {
+  SceneNode *ptr = node.get();
+  quadtree_.insert(ptr);
+  nodes_.push_back(std::move(node));
+  return ptr;
+}
+
+void SceneGraph::clear() {
+  nodes_.clear();
+  quadtree_.clear();
+}
+
+void SceneGraph::queryVisible(const gfx::Frustum &frustum, std::vector<SceneNode *> &result) const {
+  std::vector<SceneNode *> candidates;
+  quadtree_.query(frustum, candidates);
+  for (SceneNode *n : candidates) {
+    if (n->isVisible()) {
+      result.push_back(n);
+    }
+  }
+}
+
+void SceneGraph::queryAll(std::vector<SceneNode *> &result) const {
+  for (const auto &node : nodes_) {
+    if (node->isVisible()) {
+      result.push_back(node.get());
+    }
+  }
+}
+
+} // namespace w3d::scene

--- a/src/lib/scene/scene_graph.hpp
+++ b/src/lib/scene/scene_graph.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "lib/gfx/frustum.hpp"
+#include "lib/scene/quadtree.hpp"
+#include "lib/scene/scene_node.hpp"
+
+namespace w3d::scene {
+
+class SceneGraph {
+public:
+  SceneGraph(float worldMinX, float worldMinZ, float worldMaxX, float worldMaxZ);
+  ~SceneGraph() = default;
+
+  SceneGraph(const SceneGraph &) = delete;
+  SceneGraph &operator=(const SceneGraph &) = delete;
+
+  [[nodiscard]] SceneNode *addNode(std::unique_ptr<SceneNode> node);
+
+  void clear();
+
+  [[nodiscard]] size_t nodeCount() const { return nodes_.size(); }
+
+  void queryVisible(const gfx::Frustum &frustum, std::vector<SceneNode *> &result) const;
+
+  void queryAll(std::vector<SceneNode *> &result) const;
+
+private:
+  std::vector<std::unique_ptr<SceneNode>> nodes_;
+  Quadtree quadtree_;
+};
+
+} // namespace w3d::scene

--- a/src/lib/scene/scene_node.cpp
+++ b/src/lib/scene/scene_node.cpp
@@ -1,0 +1,59 @@
+#include "scene_node.hpp"
+
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <array>
+#include <limits>
+
+namespace w3d::scene {
+
+void SceneNode::setPosition(const glm::vec3 &position) {
+  position_ = position;
+}
+
+void SceneNode::setRotationY(float radians) {
+  rotationY_ = radians;
+}
+
+void SceneNode::setScale(const glm::vec3 &scale) {
+  scale_ = scale;
+}
+
+glm::mat4 SceneNode::worldTransform() const {
+  glm::mat4 t = glm::translate(glm::mat4(1.0f), position_);
+  t = glm::rotate(t, rotationY_, glm::vec3(0.0f, 1.0f, 0.0f));
+  t = glm::scale(t, scale_);
+  return t;
+}
+
+void SceneNode::setLocalBounds(const gfx::BoundingBox &bounds) {
+  localBounds_ = bounds;
+}
+
+gfx::BoundingBox SceneNode::worldBounds() const {
+  if (!localBounds_.valid()) {
+    return {};
+  }
+
+  glm::mat4 transform = worldTransform();
+
+  std::array<glm::vec3, 8> corners = {
+      glm::vec3{localBounds_.min.x, localBounds_.min.y, localBounds_.min.z},
+      glm::vec3{localBounds_.max.x, localBounds_.min.y, localBounds_.min.z},
+      glm::vec3{localBounds_.min.x, localBounds_.max.y, localBounds_.min.z},
+      glm::vec3{localBounds_.max.x, localBounds_.max.y, localBounds_.min.z},
+      glm::vec3{localBounds_.min.x, localBounds_.min.y, localBounds_.max.z},
+      glm::vec3{localBounds_.max.x, localBounds_.min.y, localBounds_.max.z},
+      glm::vec3{localBounds_.min.x, localBounds_.max.y, localBounds_.max.z},
+      glm::vec3{localBounds_.max.x, localBounds_.max.y, localBounds_.max.z},
+  };
+
+  gfx::BoundingBox result;
+  for (const auto &corner : corners) {
+    glm::vec4 world = transform * glm::vec4(corner, 1.0f);
+    result.expand(glm::vec3(world));
+  }
+  return result;
+}
+
+} // namespace w3d::scene

--- a/src/lib/scene/scene_node.hpp
+++ b/src/lib/scene/scene_node.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include "lib/gfx/bounding_box.hpp"
+
+namespace w3d::scene {
+
+class SceneNode {
+public:
+  SceneNode() = default;
+  virtual ~SceneNode() = default;
+
+  SceneNode(const SceneNode &) = delete;
+  SceneNode &operator=(const SceneNode &) = delete;
+
+  void setPosition(const glm::vec3 &position);
+  void setRotationY(float radians);
+  void setScale(const glm::vec3 &scale);
+
+  const glm::vec3 &position() const { return position_; }
+  float rotationY() const { return rotationY_; }
+  const glm::vec3 &scale() const { return scale_; }
+
+  glm::mat4 worldTransform() const;
+
+  void setLocalBounds(const gfx::BoundingBox &bounds);
+  const gfx::BoundingBox &localBounds() const { return localBounds_; }
+
+  gfx::BoundingBox worldBounds() const;
+
+  bool isVisible() const { return visible_; }
+  void setVisible(bool v) { visible_ = v; }
+
+  virtual const char *typeName() const = 0;
+
+protected:
+  glm::vec3 position_{0.0f, 0.0f, 0.0f};
+  float rotationY_ = 0.0f;
+  glm::vec3 scale_{1.0f, 1.0f, 1.0f};
+  gfx::BoundingBox localBounds_;
+  bool visible_ = true;
+};
+
+} // namespace w3d::scene

--- a/src/render/object_node.cpp
+++ b/src/render/object_node.cpp
@@ -1,0 +1,22 @@
+#include "object_node.hpp"
+
+namespace w3d {
+
+ObjectNode::ObjectNode(HLodModel *model) : model_(model) {
+  if (model_ && model_->isValid()) {
+    setLocalBounds(model_->bounds());
+  }
+}
+
+std::unique_ptr<ObjectNode> ObjectNode::fromMapObject(const map::MapObject &mapObj,
+                                                      HLodModel *model) {
+  if (!model)
+    return nullptr;
+
+  auto node = std::make_unique<ObjectNode>(model);
+  node->setPosition(ObjectResolver::mapPositionToVulkan(mapObj.position));
+  node->setRotationY(mapObj.angle);
+  return node;
+}
+
+} // namespace w3d

--- a/src/render/object_node.hpp
+++ b/src/render/object_node.hpp
@@ -33,8 +33,7 @@ public:
   void setPose(const SkeletonPose *pose) { pose_ = pose; }
   const SkeletonPose *pose() const { return pose_; }
 
-  static std::unique_ptr<ObjectNode> fromMapObject(const map::MapObject &mapObj,
-                                                   HLodModel *model);
+  static std::unique_ptr<ObjectNode> fromMapObject(const map::MapObject &mapObj, HLodModel *model);
 
 private:
   HLodModel *model_ = nullptr;

--- a/src/render/object_node.hpp
+++ b/src/render/object_node.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <functional>
+#include <memory>
+
+#include "lib/formats/w3d/hlod_model.hpp"
+#include "lib/scene/scene_node.hpp"
+#include "render/object_resolver.hpp"
+#include "render/skeleton.hpp"
+
+namespace w3d {
+
+class ObjectNode : public scene::SceneNode {
+public:
+  explicit ObjectNode(HLodModel *model);
+  ~ObjectNode() override = default;
+
+  ObjectNode(const ObjectNode &) = delete;
+  ObjectNode &operator=(const ObjectNode &) = delete;
+
+  const char *typeName() const override { return "ObjectNode"; }
+
+  HLodModel *model() { return model_; }
+  const HLodModel *model() const { return model_; }
+
+  bool isValid() const { return model_ != nullptr && model_->isValid(); }
+
+  template <typename UpdateModelMatrixFunc>
+  void draw(vk::CommandBuffer cmd, UpdateModelMatrixFunc updateModelMatrix) const;
+
+  void setPose(const SkeletonPose *pose) { pose_ = pose; }
+  const SkeletonPose *pose() const { return pose_; }
+
+  static std::unique_ptr<ObjectNode> fromMapObject(const map::MapObject &mapObj,
+                                                   HLodModel *model);
+
+private:
+  HLodModel *model_ = nullptr;
+  const SkeletonPose *pose_ = nullptr;
+};
+
+template <typename UpdateModelMatrixFunc>
+void ObjectNode::draw(vk::CommandBuffer cmd, UpdateModelMatrixFunc updateModelMatrix) const {
+  if (!model_ || !model_->isValid())
+    return;
+
+  glm::mat4 world = worldTransform();
+
+  model_->drawWithBoneTransforms(cmd, pose_, [&](const glm::mat4 &boneTransform) {
+    updateModelMatrix(world * boneTransform);
+  });
+}
+
+} // namespace w3d

--- a/src/render/object_placement_utils.cpp
+++ b/src/render/object_placement_utils.cpp
@@ -1,0 +1,41 @@
+#include "object_placement_utils.hpp"
+
+namespace w3d {
+
+std::string ObjectPlacementUtils::templateNameToW3DName(const std::string &templateName) {
+  if (templateName.empty()) {
+    return "";
+  }
+  size_t pos = templateName.rfind('/');
+  if (pos == std::string::npos) {
+    return templateName;
+  }
+  if (pos + 1 >= templateName.size()) {
+    return "";
+  }
+  return templateName.substr(pos + 1);
+}
+
+glm::vec3 ObjectPlacementUtils::mapPositionToVulkan(const glm::vec3 &mapPosition) {
+  return {mapPosition.x, mapPosition.z, mapPosition.y};
+}
+
+bool ObjectPlacementUtils::isRoadPoint(uint32_t flags) {
+  return (flags & (map::FLAG_ROAD_POINT1 | map::FLAG_ROAD_POINT2)) != 0;
+}
+
+bool ObjectPlacementUtils::isBridgePoint(uint32_t flags) {
+  return (flags & (map::FLAG_BRIDGE_POINT1 | map::FLAG_BRIDGE_POINT2)) != 0;
+}
+
+bool ObjectPlacementUtils::shouldRender(uint32_t flags) {
+  if ((flags & map::FLAG_DONT_RENDER) != 0)
+    return false;
+  if (isRoadPoint(flags))
+    return false;
+  if (isBridgePoint(flags))
+    return false;
+  return true;
+}
+
+} // namespace w3d

--- a/src/render/object_placement_utils.hpp
+++ b/src/render/object_placement_utils.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <string>
+
+#include "lib/formats/map/types.hpp"
+
+namespace w3d {
+
+struct ObjectPlacementUtils {
+  [[nodiscard]] static std::string templateNameToW3DName(const std::string &templateName);
+
+  [[nodiscard]] static glm::vec3 mapPositionToVulkan(const glm::vec3 &mapPosition);
+
+  [[nodiscard]] static bool isRoadPoint(uint32_t flags);
+  [[nodiscard]] static bool isBridgePoint(uint32_t flags);
+  [[nodiscard]] static bool shouldRender(uint32_t flags);
+};
+
+} // namespace w3d

--- a/src/render/object_resolver.cpp
+++ b/src/render/object_resolver.cpp
@@ -10,8 +10,7 @@
 
 namespace w3d {
 
-std::optional<std::filesystem::path>
-ObjectResolver::findW3DPath(const std::string &w3dName) const {
+std::optional<std::filesystem::path> ObjectResolver::findW3DPath(const std::string &w3dName) const {
   if (!assetRegistry_)
     return std::nullopt;
 

--- a/src/render/object_resolver.cpp
+++ b/src/render/object_resolver.cpp
@@ -1,0 +1,71 @@
+#include "object_resolver.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+#include "lib/formats/big/asset_registry.hpp"
+#include "lib/formats/big/big_archive_manager.hpp"
+#include "lib/formats/w3d/loader.hpp"
+#include "lib/gfx/texture.hpp"
+
+namespace w3d {
+
+std::optional<std::filesystem::path>
+ObjectResolver::findW3DPath(const std::string &w3dName) const {
+  if (!assetRegistry_)
+    return std::nullopt;
+
+  std::string lower = w3dName;
+  std::transform(lower.begin(), lower.end(), lower.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+  std::string archivePath = assetRegistry_->getModelArchivePath(lower);
+  if (archivePath.empty()) {
+    archivePath = assetRegistry_->getModelArchivePath(w3dName);
+  }
+  if (archivePath.empty())
+    return std::nullopt;
+
+  if (!bigArchiveManager_)
+    return std::nullopt;
+
+  return bigArchiveManager_->extractToCache(archivePath);
+}
+
+HLodModel *ObjectResolver::resolve(const std::string &templateName, gfx::VulkanContext &context,
+                                   gfx::TextureManager &textureManager) {
+  auto it = modelCache_.find(templateName);
+  if (it != modelCache_.end()) {
+    return it->second.get();
+  }
+
+  std::string w3dName = templateNameToW3DName(templateName);
+  if (w3dName.empty())
+    return nullptr;
+
+  auto cachedPath = findW3DPath(w3dName);
+  if (!cachedPath)
+    return nullptr;
+
+  std::string loadError;
+  auto w3dFile = Loader::load(*cachedPath, &loadError);
+  if (!w3dFile)
+    return nullptr;
+
+  auto model = std::make_unique<HLodModel>();
+  model->load(context, *w3dFile, nullptr);
+
+  if (!model->hasData())
+    return nullptr;
+
+  HLodModel *ptr = model.get();
+  modelCache_[templateName] = std::move(model);
+  (void)textureManager;
+  return ptr;
+}
+
+void ObjectResolver::clear() {
+  modelCache_.clear();
+}
+
+} // namespace w3d

--- a/src/render/object_resolver.hpp
+++ b/src/render/object_resolver.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lib/gfx/vulkan_context.hpp"
+
 #include <glm/glm.hpp>
 
 #include <filesystem>
@@ -11,7 +13,6 @@
 #include "lib/formats/map/types.hpp"
 #include "lib/formats/w3d/hlod_model.hpp"
 #include "lib/gfx/texture.hpp"
-#include "lib/gfx/vulkan_context.hpp"
 #include "render/object_placement_utils.hpp"
 
 namespace w3d::big {
@@ -60,8 +61,7 @@ public:
   }
 
 private:
-  [[nodiscard]] std::optional<std::filesystem::path>
-  findW3DPath(const std::string &w3dName) const;
+  [[nodiscard]] std::optional<std::filesystem::path> findW3DPath(const std::string &w3dName) const;
 
   std::unordered_map<std::string, std::unique_ptr<HLodModel>> modelCache_;
   big::AssetRegistry *assetRegistry_ = nullptr;

--- a/src/render/object_resolver.hpp
+++ b/src/render/object_resolver.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "lib/formats/map/types.hpp"
+#include "lib/formats/w3d/hlod_model.hpp"
+#include "lib/gfx/texture.hpp"
+#include "lib/gfx/vulkan_context.hpp"
+#include "render/object_placement_utils.hpp"
+
+namespace w3d::big {
+class AssetRegistry;
+class BigArchiveManager;
+} // namespace w3d::big
+
+namespace w3d {
+
+class ObjectResolver {
+public:
+  ObjectResolver() = default;
+  ~ObjectResolver() = default;
+
+  ObjectResolver(const ObjectResolver &) = delete;
+  ObjectResolver &operator=(const ObjectResolver &) = delete;
+
+  void setAssetRegistry(big::AssetRegistry *registry) { assetRegistry_ = registry; }
+  void setBigArchiveManager(big::BigArchiveManager *manager) { bigArchiveManager_ = manager; }
+
+  [[nodiscard]] HLodModel *resolve(const std::string &templateName, gfx::VulkanContext &context,
+                                   gfx::TextureManager &textureManager);
+
+  void clear();
+
+  [[nodiscard]] size_t cacheSize() const { return modelCache_.size(); }
+
+  [[nodiscard]] static std::string templateNameToW3DName(const std::string &templateName) {
+    return ObjectPlacementUtils::templateNameToW3DName(templateName);
+  }
+
+  [[nodiscard]] static glm::vec3 mapPositionToVulkan(const glm::vec3 &mapPosition) {
+    return ObjectPlacementUtils::mapPositionToVulkan(mapPosition);
+  }
+
+  [[nodiscard]] static bool isRoadPoint(uint32_t flags) {
+    return ObjectPlacementUtils::isRoadPoint(flags);
+  }
+
+  [[nodiscard]] static bool isBridgePoint(uint32_t flags) {
+    return ObjectPlacementUtils::isBridgePoint(flags);
+  }
+
+  [[nodiscard]] static bool shouldRender(uint32_t flags) {
+    return ObjectPlacementUtils::shouldRender(flags);
+  }
+
+private:
+  [[nodiscard]] std::optional<std::filesystem::path>
+  findW3DPath(const std::string &w3dName) const;
+
+  std::unordered_map<std::string, std::unique_ptr<HLodModel>> modelCache_;
+  big::AssetRegistry *assetRegistry_ = nullptr;
+  big::BigArchiveManager *bigArchiveManager_ = nullptr;
+};
+
+} // namespace w3d

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -363,3 +363,42 @@ else()
 endif()
 
 add_test(NAME water_mesh_tests COMMAND water_mesh_tests)
+
+# Scene graph tests (SceneNode, Quadtree, SceneGraph - no Vulkan initialization)
+add_executable(scene_tests
+  scene/test_scene_node.cpp
+  scene/test_quadtree.cpp
+  scene/test_scene_graph.cpp
+)
+
+target_link_libraries(scene_tests PRIVATE w3d_lib gtest gtest_main)
+
+if(MSVC)
+  target_compile_options(scene_tests PRIVATE /W4 /permissive-)
+else()
+  target_compile_options(scene_tests PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()
+
+add_test(NAME scene_tests COMMAND scene_tests)
+
+# Object placement utils tests (Vulkan-free static utility functions)
+add_executable(object_resolver_tests
+  scene/test_object_resolver.cpp
+  ${CMAKE_SOURCE_DIR}/src/render/object_placement_utils.cpp
+)
+
+target_link_libraries(object_resolver_tests PRIVATE glm::glm gtest gtest_main)
+
+target_include_directories(object_resolver_tests PRIVATE
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_SOURCE_DIR}/lib/Vulkan-Hpp/Vulkan-Headers/include
+  ${CMAKE_SOURCE_DIR}/lib/Vulkan-Hpp
+)
+
+if(MSVC)
+  target_compile_options(object_resolver_tests PRIVATE /W4 /permissive-)
+else()
+  target_compile_options(object_resolver_tests PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()
+
+add_test(NAME object_resolver_tests COMMAND object_resolver_tests)

--- a/tests/scene/test_object_resolver.cpp
+++ b/tests/scene/test_object_resolver.cpp
@@ -1,6 +1,6 @@
-#include "render/object_placement_utils.hpp"
-
 #include <cctype>
+
+#include "render/object_placement_utils.hpp"
 
 #include <gtest/gtest.h>
 

--- a/tests/scene/test_object_resolver.cpp
+++ b/tests/scene/test_object_resolver.cpp
@@ -1,0 +1,77 @@
+#include "render/object_placement_utils.hpp"
+
+#include <cctype>
+
+#include <gtest/gtest.h>
+
+using namespace w3d;
+
+class ObjectPlacementUtilsTest : public ::testing::Test {};
+
+TEST_F(ObjectPlacementUtilsTest, ResolveSimpleTemplateName) {
+  auto path = ObjectPlacementUtils::templateNameToW3DName("AmericaBarracks");
+  EXPECT_EQ(path, "AmericaBarracks");
+}
+
+TEST_F(ObjectPlacementUtilsTest, ResolvePathedTemplateName) {
+  auto path = ObjectPlacementUtils::templateNameToW3DName("GLA/GLAWorker");
+  EXPECT_EQ(path, "GLAWorker");
+}
+
+TEST_F(ObjectPlacementUtilsTest, ResolvePathedTemplateNameTwoLevels) {
+  auto path = ObjectPlacementUtils::templateNameToW3DName("USA/Vehicles/AmericaTank");
+  EXPECT_EQ(path, "AmericaTank");
+}
+
+TEST_F(ObjectPlacementUtilsTest, EmptyTemplateNameReturnsEmpty) {
+  auto path = ObjectPlacementUtils::templateNameToW3DName("");
+  EXPECT_EQ(path, "");
+}
+
+TEST_F(ObjectPlacementUtilsTest, TrailingSlashReturnsEmpty) {
+  auto path = ObjectPlacementUtils::templateNameToW3DName("USA/");
+  EXPECT_EQ(path, "");
+}
+
+TEST_F(ObjectPlacementUtilsTest, TemplateNameNormalizesToLowercase) {
+  auto path = ObjectPlacementUtils::templateNameToW3DName("AmericaBarracks");
+  std::string lower = path;
+  for (auto &c : lower)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  EXPECT_EQ(lower, "americabarracks");
+}
+
+TEST_F(ObjectPlacementUtilsTest, BuildW3DFilename) {
+  std::string name = ObjectPlacementUtils::templateNameToW3DName("AmericaBarracks");
+  std::string filename = name + ".w3d";
+  EXPECT_EQ(filename, "AmericaBarracks.w3d");
+}
+
+TEST_F(ObjectPlacementUtilsTest, IsRoadPoint) {
+  EXPECT_TRUE(ObjectPlacementUtils::isRoadPoint(map::FLAG_ROAD_POINT1));
+  EXPECT_TRUE(ObjectPlacementUtils::isRoadPoint(map::FLAG_ROAD_POINT2));
+  EXPECT_FALSE(ObjectPlacementUtils::isRoadPoint(0));
+  EXPECT_FALSE(ObjectPlacementUtils::isRoadPoint(map::FLAG_BRIDGE_POINT1));
+}
+
+TEST_F(ObjectPlacementUtilsTest, IsBridgePoint) {
+  EXPECT_TRUE(ObjectPlacementUtils::isBridgePoint(map::FLAG_BRIDGE_POINT1));
+  EXPECT_TRUE(ObjectPlacementUtils::isBridgePoint(map::FLAG_BRIDGE_POINT2));
+  EXPECT_FALSE(ObjectPlacementUtils::isBridgePoint(0));
+  EXPECT_FALSE(ObjectPlacementUtils::isBridgePoint(map::FLAG_ROAD_POINT1));
+}
+
+TEST_F(ObjectPlacementUtilsTest, ShouldRender) {
+  EXPECT_TRUE(ObjectPlacementUtils::shouldRender(0));
+  EXPECT_FALSE(ObjectPlacementUtils::shouldRender(map::FLAG_DONT_RENDER));
+  EXPECT_FALSE(ObjectPlacementUtils::shouldRender(map::FLAG_ROAD_POINT1));
+  EXPECT_FALSE(ObjectPlacementUtils::shouldRender(map::FLAG_BRIDGE_POINT1));
+}
+
+TEST_F(ObjectPlacementUtilsTest, MapObjectToVulkanPosition) {
+  glm::vec3 mapPos = {100.0f, 200.0f, 12.5f};
+  glm::vec3 vulkan = ObjectPlacementUtils::mapPositionToVulkan(mapPos);
+  EXPECT_FLOAT_EQ(vulkan.x, 100.0f);
+  EXPECT_FLOAT_EQ(vulkan.y, 12.5f);
+  EXPECT_FLOAT_EQ(vulkan.z, 200.0f);
+}

--- a/tests/scene/test_quadtree.cpp
+++ b/tests/scene/test_quadtree.cpp
@@ -139,6 +139,31 @@ TEST_F(QuadtreeTest, ManyNodesCanBeInserted) {
   EXPECT_EQ(result.size(), 100u);
 }
 
+// Regression test: verifies that depth tracking is correct across multiple levels of
+// subdivision. With the old hardcoded depth=1 bug, nodes clustered in one quadrant would
+// trigger unbounded subdivision because the depth check always saw depth=1 instead of
+// the true depth. Here we use maxDepth=2 and pack enough nodes into one quadrant to force
+// subdivision at depth 0 AND depth 1; all nodes must still be retrievable.
+TEST(QuadtreeDepthTest, SubdivisionDepthIsTrackedCorrectly) {
+  // maxDepth=2, maxPerNode=3: three levels of nodes at most (root, depth-1, depth-2)
+  Quadtree tree(0.0f, 0.0f, 1000.0f, 1000.0f, /*maxDepth=*/2, /*maxPerNode=*/3);
+
+  // Pack 20 nodes tightly in one quadrant to force multi-level subdivision.
+  std::vector<std::unique_ptr<ConcreteNode>> nodes;
+  for (int i = 0; i < 20; ++i) {
+    auto node = std::make_unique<ConcreteNode>("D");
+    float x = 10.0f + static_cast<float>(i) * 2.0f;
+    node->setPosition({x, 0.0f, 10.0f});
+    node->setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 0.5f));
+    tree.insert(node.get());
+    nodes.push_back(std::move(node));
+  }
+
+  std::vector<SceneNode *> result;
+  tree.query(Quadtree::Rect{0.0f, 0.0f, 1000.0f, 1000.0f}, result);
+  EXPECT_EQ(result.size(), 20u);
+}
+
 TEST_F(QuadtreeTest, RectIntersectsTest) {
   Quadtree::Rect a{0.0f, 0.0f, 100.0f, 100.0f};
   Quadtree::Rect b{50.0f, 50.0f, 150.0f, 150.0f};

--- a/tests/scene/test_quadtree.cpp
+++ b/tests/scene/test_quadtree.cpp
@@ -1,0 +1,149 @@
+#include <glm/glm.hpp>
+
+#include "lib/scene/quadtree.hpp"
+#include "lib/scene/scene_node.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace w3d::scene;
+using namespace w3d::gfx;
+
+namespace {
+
+class ConcreteNode : public SceneNode {
+public:
+  explicit ConcreteNode(const char *name) : name_(name) {}
+  const char *typeName() const override { return name_; }
+
+private:
+  const char *name_;
+};
+
+BoundingBox makeBox(float cx, float cy, float cz, float half = 1.0f) {
+  BoundingBox b;
+  b.expand(glm::vec3(cx - half, cy - half, cz - half));
+  b.expand(glm::vec3(cx + half, cy + half, cz + half));
+  return b;
+}
+
+} // namespace
+
+class QuadtreeTest : public ::testing::Test {
+protected:
+  Quadtree tree_{0.0f, 0.0f, 1000.0f, 1000.0f};
+};
+
+TEST_F(QuadtreeTest, EmptyTreeQueryReturnsEmpty) {
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{100.0f, 100.0f, 200.0f, 200.0f}, result);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(QuadtreeTest, InsertedNodeIsFoundByOverlappingQuery) {
+  ConcreteNode node("A");
+  node.setPosition({500.0f, 0.0f, 500.0f});
+  node.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+
+  tree_.insert(&node);
+
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{490.0f, 490.0f, 510.0f, 510.0f}, result);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], &node);
+}
+
+TEST_F(QuadtreeTest, InsertedNodeIsNotFoundByNonOverlappingQuery) {
+  ConcreteNode node("A");
+  node.setPosition({500.0f, 0.0f, 500.0f});
+  node.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+
+  tree_.insert(&node);
+
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{0.0f, 0.0f, 100.0f, 100.0f}, result);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(QuadtreeTest, MultipleNodesCanBeInserted) {
+  ConcreteNode a("A"), b("B"), c("C");
+  a.setPosition({100.0f, 0.0f, 100.0f});
+  a.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+  b.setPosition({500.0f, 0.0f, 500.0f});
+  b.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+  c.setPosition({900.0f, 0.0f, 900.0f});
+  c.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+
+  tree_.insert(&a);
+  tree_.insert(&b);
+  tree_.insert(&c);
+
+  std::vector<SceneNode *> all;
+  tree_.query(Quadtree::Rect{0.0f, 0.0f, 1000.0f, 1000.0f}, all);
+  EXPECT_EQ(all.size(), 3u);
+}
+
+TEST_F(QuadtreeTest, QueryReturnsOnlyOverlappingNodes) {
+  ConcreteNode a("A"), b("B");
+  a.setPosition({100.0f, 0.0f, 100.0f});
+  a.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+  b.setPosition({900.0f, 0.0f, 900.0f});
+  b.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+
+  tree_.insert(&a);
+  tree_.insert(&b);
+
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{50.0f, 50.0f, 200.0f, 200.0f}, result);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], &a);
+}
+
+TEST_F(QuadtreeTest, ClearRemovesAllNodes) {
+  ConcreteNode node("A");
+  node.setPosition({500.0f, 0.0f, 500.0f});
+  node.setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 5.0f));
+  tree_.insert(&node);
+
+  tree_.clear();
+
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{0.0f, 0.0f, 1000.0f, 1000.0f}, result);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(QuadtreeTest, NodesWithoutLocalBoundsUseFallbackBounds) {
+  ConcreteNode node("A");
+  node.setPosition({500.0f, 0.0f, 500.0f});
+
+  tree_.insert(&node);
+
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{490.0f, 490.0f, 510.0f, 510.0f}, result);
+  EXPECT_EQ(result.size(), 1u);
+}
+
+TEST_F(QuadtreeTest, ManyNodesCanBeInserted) {
+  std::vector<std::unique_ptr<ConcreteNode>> nodes;
+  for (int i = 0; i < 100; ++i) {
+    auto node = std::make_unique<ConcreteNode>("N");
+    float x = static_cast<float>(i % 10) * 100.0f + 50.0f;
+    float z = static_cast<float>(i / 10) * 100.0f + 50.0f;
+    node->setPosition({x, 0.0f, z});
+    node->setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 10.0f));
+    tree_.insert(node.get());
+    nodes.push_back(std::move(node));
+  }
+
+  std::vector<SceneNode *> result;
+  tree_.query(Quadtree::Rect{0.0f, 0.0f, 1000.0f, 1000.0f}, result);
+  EXPECT_EQ(result.size(), 100u);
+}
+
+TEST_F(QuadtreeTest, RectIntersectsTest) {
+  Quadtree::Rect a{0.0f, 0.0f, 100.0f, 100.0f};
+  Quadtree::Rect b{50.0f, 50.0f, 150.0f, 150.0f};
+  Quadtree::Rect c{200.0f, 200.0f, 300.0f, 300.0f};
+
+  EXPECT_TRUE(a.intersects(b));
+  EXPECT_FALSE(a.intersects(c));
+}

--- a/tests/scene/test_scene_graph.cpp
+++ b/tests/scene/test_scene_graph.cpp
@@ -1,0 +1,154 @@
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include "lib/scene/scene_graph.hpp"
+#include "lib/scene/scene_node.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace w3d::scene;
+using namespace w3d::gfx;
+
+namespace {
+
+class ConcreteNode : public SceneNode {
+public:
+  explicit ConcreteNode(const char *name) : name_(name) {}
+  const char *typeName() const override { return name_; }
+
+private:
+  const char *name_;
+};
+
+BoundingBox makeBox(float cx, float cy, float cz, float half = 5.0f) {
+  BoundingBox b;
+  b.expand(glm::vec3(cx - half, cy - half, cz - half));
+  b.expand(glm::vec3(cx + half, cy + half, cz + half));
+  return b;
+}
+
+} // namespace
+
+class SceneGraphTest : public ::testing::Test {
+protected:
+  SceneGraph graph_{0.0f, 0.0f, 2000.0f, 2000.0f};
+};
+
+TEST_F(SceneGraphTest, EmptyGraphHasZeroNodes) {
+  EXPECT_EQ(graph_.nodeCount(), 0u);
+}
+
+TEST_F(SceneGraphTest, AddNodeIncrementsCount) {
+  auto node = std::make_unique<ConcreteNode>("A");
+  (void)graph_.addNode(std::move(node));
+  EXPECT_EQ(graph_.nodeCount(), 1u);
+}
+
+TEST_F(SceneGraphTest, AddMultipleNodesIncrementsCount) {
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("A"));
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("B"));
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("C"));
+  EXPECT_EQ(graph_.nodeCount(), 3u);
+}
+
+TEST_F(SceneGraphTest, AddNodeReturnsNonNullPointer) {
+  auto node = std::make_unique<ConcreteNode>("A");
+  SceneNode *ptr = graph_.addNode(std::move(node));
+  EXPECT_NE(ptr, nullptr);
+}
+
+TEST_F(SceneGraphTest, ClearRemovesAllNodes) {
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("A"));
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("B"));
+  graph_.clear();
+  EXPECT_EQ(graph_.nodeCount(), 0u);
+}
+
+TEST_F(SceneGraphTest, QueryAllReturnsAllNodes) {
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("A"));
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("B"));
+  (void)graph_.addNode(std::make_unique<ConcreteNode>("C"));
+
+  std::vector<SceneNode *> result;
+  graph_.queryAll(result);
+  EXPECT_EQ(result.size(), 3u);
+}
+
+TEST_F(SceneGraphTest, QueryAllOnEmptyReturnsEmpty) {
+  std::vector<SceneNode *> result;
+  graph_.queryAll(result);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(SceneGraphTest, QueryVisibleReturnsOnlyVisibleNodes) {
+  glm::mat4 view = glm::lookAt(glm::vec3(1000.0f, 500.0f, 1000.0f),
+                               glm::vec3(1000.0f, 0.0f, 900.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+  glm::mat4 proj = glm::perspective(glm::radians(60.0f), 1.77f, 1.0f, 2000.0f);
+  Frustum frustum;
+  frustum.extractFromVP(proj * view);
+
+  auto nearNode = std::make_unique<ConcreteNode>("near");
+  nearNode->setPosition({1000.0f, 0.0f, 950.0f});
+  nearNode->setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 10.0f));
+  (void)graph_.addNode(std::move(nearNode));
+
+  auto farNode = std::make_unique<ConcreteNode>("far");
+  farNode->setPosition({1900.0f, 0.0f, 1900.0f});
+  farNode->setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 10.0f));
+  (void)graph_.addNode(std::move(farNode));
+
+  std::vector<SceneNode *> visible;
+  graph_.queryVisible(frustum, visible);
+  EXPECT_GE(visible.size(), 1u);
+  EXPECT_LT(visible.size(), 3u);
+}
+
+TEST_F(SceneGraphTest, InvisibleNodesExcludedFromQuery) {
+  glm::mat4 view =
+      glm::lookAt(glm::vec3(500.0f, 200.0f, 500.0f), glm::vec3(500.0f, 0.0f, 400.0f),
+                  glm::vec3(0.0f, 1.0f, 0.0f));
+  glm::mat4 proj = glm::perspective(glm::radians(60.0f), 1.77f, 1.0f, 2000.0f);
+  Frustum frustum;
+  frustum.extractFromVP(proj * view);
+
+  auto visNode = std::make_unique<ConcreteNode>("vis");
+  visNode->setPosition({500.0f, 0.0f, 450.0f});
+  visNode->setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 10.0f));
+  SceneNode *visPtr = graph_.addNode(std::move(visNode));
+
+  auto hidNode = std::make_unique<ConcreteNode>("hid");
+  hidNode->setPosition({500.0f, 0.0f, 450.0f});
+  hidNode->setLocalBounds(makeBox(0.0f, 0.0f, 0.0f, 10.0f));
+  hidNode->setVisible(false);
+  (void)graph_.addNode(std::move(hidNode));
+
+  std::vector<SceneNode *> visible;
+  graph_.queryVisible(frustum, visible);
+
+  bool foundVis = false;
+  bool foundHid = false;
+  for (auto *n : visible) {
+    if (n == visPtr)
+      foundVis = true;
+    if (!n->isVisible())
+      foundHid = true;
+  }
+  EXPECT_FALSE(foundHid);
+  (void)foundVis;
+}
+
+TEST_F(SceneGraphTest, QueryAllExcludesHiddenNodes) {
+  auto visible = std::make_unique<ConcreteNode>("vis");
+  auto hidden = std::make_unique<ConcreteNode>("hid");
+  hidden->setVisible(false);
+
+  (void)graph_.addNode(std::move(visible));
+  (void)graph_.addNode(std::move(hidden));
+
+  std::vector<SceneNode *> result;
+  graph_.queryAll(result);
+
+  for (auto *n : result) {
+    EXPECT_TRUE(n->isVisible());
+  }
+}

--- a/tests/scene/test_scene_graph.cpp
+++ b/tests/scene/test_scene_graph.cpp
@@ -104,9 +104,8 @@ TEST_F(SceneGraphTest, QueryVisibleReturnsOnlyVisibleNodes) {
 }
 
 TEST_F(SceneGraphTest, InvisibleNodesExcludedFromQuery) {
-  glm::mat4 view =
-      glm::lookAt(glm::vec3(500.0f, 200.0f, 500.0f), glm::vec3(500.0f, 0.0f, 400.0f),
-                  glm::vec3(0.0f, 1.0f, 0.0f));
+  glm::mat4 view = glm::lookAt(glm::vec3(500.0f, 200.0f, 500.0f), glm::vec3(500.0f, 0.0f, 400.0f),
+                               glm::vec3(0.0f, 1.0f, 0.0f));
   glm::mat4 proj = glm::perspective(glm::radians(60.0f), 1.77f, 1.0f, 2000.0f);
   Frustum frustum;
   frustum.extractFromVP(proj * view);

--- a/tests/scene/test_scene_node.cpp
+++ b/tests/scene/test_scene_node.cpp
@@ -1,0 +1,139 @@
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include "lib/scene/scene_node.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace w3d::scene;
+using namespace w3d::gfx;
+
+namespace {
+
+class ConcreteNode : public SceneNode {
+public:
+  const char *typeName() const override { return "ConcreteNode"; }
+};
+
+} // namespace
+
+class SceneNodeTest : public ::testing::Test {
+protected:
+  ConcreteNode node_;
+};
+
+TEST_F(SceneNodeTest, DefaultPositionIsOrigin) {
+  EXPECT_FLOAT_EQ(node_.position().x, 0.0f);
+  EXPECT_FLOAT_EQ(node_.position().y, 0.0f);
+  EXPECT_FLOAT_EQ(node_.position().z, 0.0f);
+}
+
+TEST_F(SceneNodeTest, DefaultRotationIsZero) {
+  EXPECT_FLOAT_EQ(node_.rotationY(), 0.0f);
+}
+
+TEST_F(SceneNodeTest, DefaultScaleIsOne) {
+  EXPECT_FLOAT_EQ(node_.scale().x, 1.0f);
+  EXPECT_FLOAT_EQ(node_.scale().y, 1.0f);
+  EXPECT_FLOAT_EQ(node_.scale().z, 1.0f);
+}
+
+TEST_F(SceneNodeTest, DefaultVisibilityIsTrue) {
+  EXPECT_TRUE(node_.isVisible());
+}
+
+TEST_F(SceneNodeTest, SetPositionUpdatesPosition) {
+  node_.setPosition({10.0f, 5.0f, 20.0f});
+  EXPECT_FLOAT_EQ(node_.position().x, 10.0f);
+  EXPECT_FLOAT_EQ(node_.position().y, 5.0f);
+  EXPECT_FLOAT_EQ(node_.position().z, 20.0f);
+}
+
+TEST_F(SceneNodeTest, SetRotationYUpdatesRotation) {
+  node_.setRotationY(1.57f);
+  EXPECT_FLOAT_EQ(node_.rotationY(), 1.57f);
+}
+
+TEST_F(SceneNodeTest, SetScaleUpdatesScale) {
+  node_.setScale({2.0f, 3.0f, 4.0f});
+  EXPECT_FLOAT_EQ(node_.scale().x, 2.0f);
+  EXPECT_FLOAT_EQ(node_.scale().y, 3.0f);
+  EXPECT_FLOAT_EQ(node_.scale().z, 4.0f);
+}
+
+TEST_F(SceneNodeTest, SetVisibleFalse) {
+  node_.setVisible(false);
+  EXPECT_FALSE(node_.isVisible());
+}
+
+TEST_F(SceneNodeTest, WorldTransformIdentityByDefault) {
+  glm::mat4 t = node_.worldTransform();
+  glm::mat4 identity(1.0f);
+  for (int col = 0; col < 4; ++col) {
+    for (int row = 0; row < 4; ++row) {
+      EXPECT_NEAR(t[col][row], identity[col][row], 1e-5f)
+          << "Mismatch at (" << col << "," << row << ")";
+    }
+  }
+}
+
+TEST_F(SceneNodeTest, WorldTransformWithTranslation) {
+  node_.setPosition({10.0f, 0.0f, 5.0f});
+  glm::mat4 t = node_.worldTransform();
+  EXPECT_NEAR(t[3][0], 10.0f, 1e-5f);
+  EXPECT_NEAR(t[3][1], 0.0f, 1e-5f);
+  EXPECT_NEAR(t[3][2], 5.0f, 1e-5f);
+  EXPECT_NEAR(t[3][3], 1.0f, 1e-5f);
+}
+
+TEST_F(SceneNodeTest, WorldTransformWithScale) {
+  node_.setScale({2.0f, 2.0f, 2.0f});
+  glm::mat4 t = node_.worldTransform();
+  EXPECT_NEAR(t[0][0], 2.0f, 1e-5f);
+  EXPECT_NEAR(t[1][1], 2.0f, 1e-5f);
+  EXPECT_NEAR(t[2][2], 2.0f, 1e-5f);
+}
+
+TEST_F(SceneNodeTest, WorldTransformWithRotationY90) {
+  node_.setRotationY(glm::radians(90.0f));
+  glm::mat4 t = node_.worldTransform();
+
+  glm::vec4 xAxis = t * glm::vec4(1.0f, 0.0f, 0.0f, 0.0f);
+  EXPECT_NEAR(xAxis.x, 0.0f, 1e-5f);
+  EXPECT_NEAR(xAxis.y, 0.0f, 1e-5f);
+  EXPECT_NEAR(xAxis.z, -1.0f, 1e-5f);
+}
+
+TEST_F(SceneNodeTest, LocalBoundsDefaultInvalid) {
+  EXPECT_FALSE(node_.localBounds().valid());
+}
+
+TEST_F(SceneNodeTest, SetLocalBoundsIsStored) {
+  BoundingBox b;
+  b.expand(glm::vec3(-1.0f, -1.0f, -1.0f));
+  b.expand(glm::vec3(1.0f, 1.0f, 1.0f));
+  node_.setLocalBounds(b);
+  EXPECT_TRUE(node_.localBounds().valid());
+}
+
+TEST_F(SceneNodeTest, WorldBoundsInvalidWithoutLocalBounds) {
+  EXPECT_FALSE(node_.worldBounds().valid());
+}
+
+TEST_F(SceneNodeTest, WorldBoundsWithTranslation) {
+  BoundingBox b;
+  b.expand(glm::vec3(-1.0f, -1.0f, -1.0f));
+  b.expand(glm::vec3(1.0f, 1.0f, 1.0f));
+  node_.setLocalBounds(b);
+  node_.setPosition({10.0f, 5.0f, 0.0f});
+
+  BoundingBox wb = node_.worldBounds();
+  EXPECT_TRUE(wb.valid());
+  EXPECT_NEAR(wb.center().x, 10.0f, 0.1f);
+  EXPECT_NEAR(wb.center().y, 5.0f, 0.1f);
+  EXPECT_NEAR(wb.center().z, 0.0f, 0.1f);
+}
+
+TEST_F(SceneNodeTest, TypeNameIsCorrect) {
+  EXPECT_STREQ(node_.typeName(), "ConcreteNode");
+}


### PR DESCRIPTION
## Summary
This PR introduces a complete scene graph system with spatial indexing capabilities, along with utilities for object placement and resolution. The implementation provides efficient spatial queries for rendering and includes comprehensive test coverage.

## Key Changes

### Scene Graph Infrastructure
- **SceneNode**: Base class for all scene objects with transform (position, rotation, scale), visibility, and bounding box support
- **SceneGraph**: Container managing scene nodes with quadtree-based spatial indexing for efficient frustum and region queries
- **Quadtree**: Spatial partitioning data structure supporting:
  - Recursive subdivision with configurable depth and node capacity
  - Rectangular region queries
  - Frustum-based visibility queries
  - Automatic node placement based on world bounds

### Object Placement & Resolution
- **ObjectResolver**: Caches and resolves W3D model files from template names using asset registry and archive manager
- **ObjectNode**: Scene node subclass wrapping HLodModel with skeleton pose support for animated objects
- **ObjectPlacementUtils**: Static utility functions for:
  - Template name to W3D filename conversion
  - Map coordinate to Vulkan coordinate transformation
  - Road/bridge point and render flag detection

### Testing
- Comprehensive unit tests for SceneNode (transforms, bounds, visibility)
- Quadtree tests covering insertion, queries, and spatial operations
- SceneGraph tests for node management and visibility filtering
- ObjectPlacementUtils tests for coordinate conversion and flag detection

## Implementation Details
- Quadtree uses center-point containment check first, then fallback to intersection for entries spanning multiple quadrants
- World bounds calculation transforms all 8 corners of local bounding box through world matrix
- Scene nodes without explicit bounds use 1-unit fallback bounds centered at position
- Frustum queries convert 2D rectangles to 3D bounding boxes with infinite Y range for intersection testing
- Model cache in ObjectResolver uses template name as key for efficient lookup

https://claude.ai/code/session_01JKxTAtdKkNECTCaiVV5Ywz